### PR TITLE
Allow plots without quote mechanism

### DIFF
--- a/src/display.lisp
+++ b/src/display.lisp
@@ -115,17 +115,17 @@ Lisp printer. In most cases this is enough but specializations are
   ;; no rendering by default
   nil)
 
-(defun ends-with-p (str1 str2)
+(defun ends-with (str1 str2)
   (let ((p (mismatch str2 str1 :from-end T)))
     (or (not p) (= 0 p))))
 
 (defun render-image (value ext base64)
   (if (and
-        (consp value)
+        (listp value)
         (eq (caar value) 'maxima::mlist)
         (eq (list-length value) 3)
-        (ends-with-p (cadr value) ".gnuplot")
-        (ends-with-p (caddr value) ext))
+        (ends-with (cadr value) ".gnuplot")
+        (ends-with (caddr value) ext))
     (if base64
       (file-to-base64-string (caddr value))
       ;; substitute spaces for tabs in SVG file; otherwise tabs seem
@@ -139,13 +139,13 @@ Lisp printer. In most cases this is enough but specializations are
  encoding is a Base64-encoded string."))
 
 (defmethod render-pdf ((value t))
-  (render-image value ".pdf"))
+  (render-image value ".pdf" t))
 
 (defgeneric render-svg (value)
   (:documentation "Render the VALUE as a SVG image (XML format represented as a string)."))
 
 (defmethod render-svg ((value t))
-  (render-image value ".svg"))
+  (render-image value ".svg" nil))
 
 ;; nicked from: http://rosettacode.org/wiki/Read_entire_file#Common_Lisp
 (defun file-slurp (path)

--- a/src/display.lisp
+++ b/src/display.lisp
@@ -104,7 +104,7 @@ Lisp printer. In most cases this is enough but specializations are
  encoding is a Base64-encoded string."))
 
 (defmethod render-png ((value t))
-  (render-image value ".png" t))
+  (render-plot value ".png" t))
 
 (defgeneric render-jpeg (value)
   (:documentation "Render the VALUE as a JPEG image. The expected
@@ -114,16 +114,17 @@ Lisp printer. In most cases this is enough but specializations are
   ;; no rendering by default
   nil)
 
-(defun ends-with (str1 str2)
+;; nicked from: https://rosettacode.org/wiki/String_matching#Common_Lisp
+(defun ends-with-p (str1 str2)
   (let ((p (mismatch str2 str1 :from-end T)))
     (or (not p) (= 0 p))))
 
 (defun plot-p (value)
   (and (listp value) (eq (caar value) 'maxima::mlist)
-    (eq (list-length value) 3) (ends-with (cadr value) ".gnuplot")))
+    (eq (list-length value) 3) (ends-with-p (cadr value) ".gnuplot")))
 
-(defun render-image (value ext base64)
-  (if (and (plot-p value) (ends-with (caddr value) ext))
+(defun render-plot (value ext base64)
+  (if (and (plot-p value) (ends-with-p (caddr value) ext))
     (if base64
       (file-to-base64-string (caddr value))
       ;; substitute spaces for tabs in SVG file; otherwise tabs seem
@@ -137,13 +138,13 @@ Lisp printer. In most cases this is enough but specializations are
  encoding is a Base64-encoded string."))
 
 (defmethod render-pdf ((value t))
-  (render-image value ".pdf" t))
+  (render-plot value ".pdf" t))
 
 (defgeneric render-svg (value)
   (:documentation "Render the VALUE as a SVG image (XML format represented as a string)."))
 
 (defmethod render-svg ((value t))
-  (render-image value ".svg" nil))
+  (render-plot value ".svg" nil))
 
 ;; nicked from: http://rosettacode.org/wiki/Read_entire_file#Common_Lisp
 (defun file-slurp (path)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -12,6 +12,7 @@
            #:vbinds
            #:afetch
 	   #:while
+     #:file-to-base64-string
 	   #:read-file-lines
 	   #:read-string-file
 	   #:read-binary-file))


### PR DESCRIPTION
This PR removes the need to quote `plot2d` and adds support for other plot commands. There are still some issues left to be resolved as detailed below. Current usage is:

```
set_plot_option([svg_file, "foo.svg"]);
plot2d (sin(x), [x, -%pi, %pi]);
plot3d (u^2 - v^2, [u, -2, 2], [v, -3, 3], [grid, 100, 100],[mesh_lines_color,false]);
```

## Issues
- [ ] Automatically call `set_plot_option` with a default of `svg_file`.
- [x] contour_plot
- [ ] implicit_plot
- [x] julia 
- [x] mandelbrot
- [x] plot2d
- [x] plot3d
- [ ] Allow multple plots in single code block. This doesn't work because `parse_string` only parses the first string.
- [ ] Gracefully fail if gnuplot is not present