### PR TITLE
Allow multiple input lines in execute request

### DIFF
--- a/make-maxima-jupyter-recipe.txt
+++ b/make-maxima-jupyter-recipe.txt
@@ -10,11 +10,9 @@
 
 shell input --> $ mkdir -p binary/binary-openmcl
 shell input --> $ maxima -l ccl
-maxima input--> (%i1) parse_string ("1"); /* causes stringproc package to be loaded */
 maxima input--> (%i2) :lisp (require :sb-rotate-byte) ;; FOR SBCL ONLY
 maxima input--> (%i2) :lisp (load "path/to/load-maxima-jupyter.lisp")
 FOR CLOZURE CL:
 maxima input--> (%i2) :lisp (ccl:save-application "binary/binary-openmcl/maxima-jupyter" :toplevel-function 'cl-jupyter:kernel-start :prepend-kernel t)
 FOR SBCL:
 maxima input--> (%i2) :lisp (sb-ext:save-lisp-and-die #P"binary/binary-sbcl/maxima-jupyter-exec" :executable t :toplevel 'cl-jupyter:kernel-start)
-

--- a/src/evaluator.lisp
+++ b/src/evaluator.lisp
@@ -5,7 +5,7 @@
 # Evaluator #
 
 The evaluator is where the "interesting stuff" takes place :
- user expressions are evaluated here. 
+ user expressions are evaluated here.
 
 The history of evaluations is also saved by the evaluator.
 
@@ -30,56 +30,44 @@ The history of evaluations is also saved by the evaluator.
 (defmacro handling-errors (&body body)
   `(catch 'maxima::return-from-debugger
     (handler-case (progn ,@body)
-       (simple-condition (err) 
+       (simple-condition (err)
          (format *error-output* "~&~A: ~%" (class-name (class-of err)))
          (apply (function format) *error-output*
                 (simple-condition-format-control   err)
                 (simple-condition-format-arguments err))
          (format *error-output* "~&"))
-       (condition (err) 
+       (condition (err)
          (format *error-output* "~&~A: ~%  ~S~%"
                  (class-name (class-of err)) err)))))
+
+(defun mread (input)
+  (when (and (open-stream-p input) (peek-char nil input nil))
+    (maxima::mread-noprompt input nil)))
 
 (defun evaluate-code (evaluator code)
   (when maxima::$debug_evaluator
     (format t "[Evaluator] unparsed input: ~W~%" code)
     (terpri))
   (vector-push code (evaluator-history-in evaluator))
-  (let ((execution-count (length (evaluator-history-in evaluator))))
-    (let ((code-to-eval
-            (handling-errors
-              (let ((*package* (find-package :maxima)))
-                (maxima::$parse_string (format nil "~A" code))))))
-      (if (and (consp code-to-eval)
-	       (eql (car code-to-eval) 'quicklisp-client:quickload)
-	       (stringp (cadr code-to-eval)))
-	  ;; quicklisp hook
-	  (let ((results (multiple-value-list (ql:quickload (cadr code-to-eval)))))
-	    (values execution-count results "" ""))
-	  ;; else "normal" evaluation
-	  (progn 
-        (when maxima::$debug_evaluator
-          (format t "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
-          (terpri))
-	    (let* ((stdout-str (make-array 0 :element-type 'character :fill-pointer 0 :adjustable t))
-		   (stderr-str (make-array 0 :element-type 'character :fill-pointer 0 :adjustable t)))
-	      (let ((results (with-output-to-string (stdout stdout-str)
-			       (with-output-to-string (stderr stderr-str)
-			         (let ((*standard-output* stdout)
-				       (*error-output* stderr))
-				   (handling-errors
-					  ;(if (and (consp code-to-eval)
-					  ;	(eql (car code-to-eval) 'quicklisp-client:quickload)
-					  ;	(stringp (cadr code-to-eval)))
-				    ;; quicklisp hook
-					  ;  (multiple-value-list (ql:quickload (cadr code-to-eval)))
-				    ;; normal evaluation
-				    (multiple-value-list
-				      (let ((*package* (find-package :maxima)))
-				        (setq maxima::$% (maxima::meval* code-to-eval))))))))));)
-	      (when maxima::$debug_evaluator
-            (format t "[Evaluator] evaluated result: ~W~%" results)
-            (terpri))
-	      (vector-push results (evaluator-history-out evaluator))
-	      (values execution-count results stdout-str stderr-str))))))))
-
+  (let* ((execution-count (length (evaluator-history-in evaluator)))
+         (stdout (make-string-output-stream))
+         (stderr (make-string-output-stream))
+         (input (make-string-input-stream code))
+         (results (do ((results '())
+                       (code-to-eval (mread input) (mread input)))
+                    ((not code-to-eval) (reverse results))
+                    (when maxima::$debug_evaluator
+                      (format t "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
+                      (terpri))
+                    (let ((result (handling-errors
+                                   (let ((*standard-output* stdout)
+                                         (*error-output* stderr)
+                                         (*package* (find-package :maxima)))
+                              				   (setq maxima::$% (maxima::meval* code-to-eval))))))
+                      (when maxima::$debug_evaluator
+                        (format t "[Evaluator] evaluated result: ~W~%" result)
+                        (terpri))
+                  	   (setq results (cons result results))))))
+    (vector-push results (evaluator-history-out evaluator))
+    (values execution-count results
+            (get-output-stream-string stdout) (get-output-stream-string stderr))))


### PR DESCRIPTION
This PR removes dependence on `parse_string` and uses `mread-noprompt` to behave more like a Maxima notebook/prompt, i.e. allowing multiple terminated commands in an execute request. The results are then passed back each in a `execute_result` message.

This also makes it possible to write complete Maxima scripts in Pweave document. In other words, the following will work and not just execute the first command only.

```latex
%!TeX pweaveKernel=maxima
\documentclass{article}

\begin{document}
Solve an equation and make a graph!
<<fig = True>>=
solve(x^3+2);
set_plot_option([pdf_file, "foo.pdf"])$
plot3d (u^2 - v^2, [u, -2, 2], [v, -3, 3], [grid, 100, 100], [mesh_lines_color,false]);
@
\end{document}
```

Since there are some significant changes here, more testing is probably needed before merge along with resolving the following issues.

## Issues

- [ ] I can't find any use of the `quicklisp` hook. I removed it, but can add it back if needed.
- [ ] Since `parse_string` is no longer used, do we need something like `ensure_terminator`?
- [ ] Make sure that the `ask` functions work.