### PR TITLE
Add support for is_complete_request and shutdown_request

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -13,6 +13,7 @@
            #:while
            #:add-terminator
            #:ends-with-p
+           #:ends-with-terminator
            #:file-to-base64-string
            #:read-file-lines
            #:read-string-file

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -44,7 +44,7 @@
 		      ((equal msg-type "execute_request")
 		       (setf active (handle-execute-request shell identities msg buffers)))
 		      ((equal msg-type "shutdown_request")
-		       (setf active (handle-shutdate-request shell identities msg buffers)))
+		       (setf active (handle-shutdown-request shell identities msg buffers)))
 		      ((equal msg-type "is_complete_request")
 		       (handle-is-complete-request shell identities msg buffers))
 		      (t (warn "[Shell] message type '~A' not (yet ?) supported, skipping..." msg-type))))))))

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -43,12 +43,11 @@
 		       (handle-kernel-info-request shell identities msg buffers))
 		      ((equal msg-type "execute_request")
 		       (setf active (handle-execute-request shell identities msg buffers)))
-          ((equal msg-type "shutdown_request")
-           (setf active (handle-shutdown-request shell identities msg buffers)))
-          ((equal msg-type "is_complete_request")
-           (handle-is-complete-request shell identities msg buffers))
+		      ((equal msg-type "shutdown_request")
+		       (setf active (handle-shutdate-request shell identities msg buffers)))
+		      ((equal msg-type "is_complete_request")
+		       (handle-is-complete-request shell identities msg buffers))
 		      (t (warn "[Shell] message type '~A' not (yet ?) supported, skipping..." msg-type))))))))
-
 
 #|
 
@@ -160,49 +159,42 @@
 
   (defun handle-execute-request (shell identities msg buffers)
     ;;(format t "[Shell] handling 'execute_request'~%")
-    (send-status-update (kernel-iopub (shell-kernel shell)) msg "busy" :key (kernel-key shell))
-    (let ((content (parse-json-from-string (message-content msg))))
-      ;;(format t "  ==> Message content = ~W~%" content)
-      (let ((code (afetch "code" content :test #'equal)))
-        (setq execute-request-shell shell)
-        (setq execute-request-msg msg)
-        ;;(format t "  ===> Code to execute = ~W~%" code)
-        (vbinds (execution-count results stdout stderr)
-            (evaluate-code (kernel-evaluator (shell-kernel shell)) code)
-          ;(format t "Execution count = ~A~%" execution-count)
-          ;(format t "results = ~A~%" results)
-          ;(format t "STDOUT = ~A~%" stdout)
-          ;(format t "STDERR = ~A~%" stderr)
-          ;broadcast the code to connected frontends
-	  (send-execute-code (kernel-iopub (shell-kernel shell)) msg execution-count code :key (kernel-key shell))
-  	(when (and (consp results) (typep (car results) 'cl-jupyter-user::cl-jupyter-quit-obj))
-  	  ;; ----- ** request for shutdown ** -----
-  	  (let ((reply (make-message msg "execute_reply" nil
-  				     `(("status" . "abort")
-  				       ("execution_count" . ,execution-count)))))
-	    (message-send (shell-socket shell) reply :identities identities :key (kernel-key shell)))
-  	  (return-from handle-execute-request nil))
-  	;; ----- ** normal request ** -----
-          ;; send the stdout
-          (when (and stdout (> (length stdout) 0))
-	    (send-stream (kernel-iopub (shell-kernel shell)) msg "stdout" stdout :key (kernel-key shell)))
-          ;; send the stderr
-          (when (and stderr (> (length stderr) 0))
-	    (send-stream (kernel-iopub (shell-kernel shell)) msg "stderr" stderr :key (kernel-key shell)))
-  	;; send the results
-    (dolist (result results)
-      (when (eq (caar result) 'maxima::displayinput)
-      	(send-execute-result (kernel-iopub (shell-kernel shell))
-    			     msg execution-count (caddr result) :key (kernel-key shell))))
-  	;; status back to idle
-	(send-status-update (kernel-iopub (shell-kernel shell)) msg "idle" :key (kernel-key shell))
-  	;; send reply (control)
-  	(let ((reply (make-message msg "execute_reply" nil
-  				   `(("status" . "ok")
-  				     ("execution_count" . ,execution-count)
-  				     ("payload" . ,(vector))))))
-	  (message-send (shell-socket shell) reply :identities identities :key (kernel-key shell))
-  	  t)))))
+    (let* ((key (kernel-key shell))
+           (iopub (kernel-iopub (shell-kernel shell)))
+           (content (parse-json-from-string (message-content msg)))
+           (code (afetch "code" content :test #'equal)))
+      (send-status-update (kernel-iopub (shell-kernel shell)) msg "busy" :key key)
+      (setq execute-request-shell shell)
+      (setq execute-request-msg msg)
+      ;;(format t "  ===> Code to execute = ~W~%" code)
+      (vbinds (execution-count results stdout stderr)
+              (evaluate-code (kernel-evaluator (shell-kernel shell)) code)
+        ;(format t "Execution count = ~A~%" execution-count)
+        ;(format t "results = ~A~%" results)
+        ;(format t "STDOUT = ~A~%" stdout)
+        ;(format t "STDERR = ~A~%" stderr)
+        ;broadcast the code to connected frontends
+        (send-execute-code iopub msg execution-count code :key key)
+        (when (and (consp results) (typep (car results) 'cl-jupyter-user::cl-jupyter-quit-obj))
+              ;; ----- ** request for shutdown ** -----
+              (send-execute-reply shell identities msg "abort" execution-count :key key)
+              (return-from handle-execute-request nil))
+        ;; ----- ** normal request ** -----
+        ;; send the stdout
+        (when (and stdout (> (length stdout) 0))
+              (send-stream iopub msg "stdout" stdout :key key))
+        ;; send the stderr
+        (when (and stderr (> (length stderr) 0))
+              (send-stream iopub msg "stderr" stderr :key key))
+        ;; send the results
+        (dolist (result results)
+          (when (eq (caar result) 'maxima::displayinput)
+                (send-execute-result iopub msg execution-count (caddr result) :key key)))
+        ;; status back to idle
+        (send-status-update iopub msg "idle" :key key)
+        ;; send reply (control)
+        (send-execute-reply shell identities msg "ok" execution-count :key key)
+  	    t)))
 
   ;; Redefine RETRIEVE in src/macsys.lisp to make use of input-request/input-reply.
   ;; MSG, FLAG, and PRINT? are declared special there, so be careful to
@@ -275,6 +267,13 @@
   (let ((msg (make-message parent-msg "is_complete_reply" nil
                            `(("status" . ,status)
                              ("indent" . "")))))
+    (message-send (shell-socket shell) msg :identities identities :key key)))
+
+(defun send-execute-reply (shell identities parent-msg status execution-count &key (key nil))
+  (let ((msg (make-message parent-msg "execute_reply" nil
+                           `(("status" . ,status)
+                             ("execution_count" . ,execution-count)
+                             ("payload" . ,(vector))))))
     (message-send (shell-socket shell) msg :identities identities :key key)))
 
 #|

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -146,10 +146,13 @@
   (let ((p (mismatch str2 str1 :from-end T)))
     (or (not p) (= 0 p))))
 
-(defun add-terminator (code)
+(defun ends-with-terminator (code)
   (let ((trimmed (string-right-trim
                   '(#\Space #\Newline #\Backspace #\Tab #\Linefeed #\Page #\Return #\Rubout)
                   code)))
-    (if (or (ends-with-p trimmed "$") (ends-with-p trimmed ";"))
-      code
-      (concatenate 'string code ";"))))
+    (or (ends-with-p trimmed "$") (ends-with-p trimmed ";"))))
+
+(defun add-terminator (code)
+  (if (ends-with-terminator code)
+    code
+    (concatenate 'string code ";")))


### PR DESCRIPTION
This PR adds support for the `is_complete_request` and the `shutdown_request` messages. It also cleans up `handle-execute-request` and `handle-kernel-info-request` a bit.