### PR TITLE
Improve messaging and capture Maxima errors

### DIFF
--- a/src/evaluator.lisp
+++ b/src/evaluator.lisp
@@ -26,25 +26,36 @@ The history of evaluations is also saved by the evaluator.
     (setf (slot-value kernel 'evaluator) evaluator)
     evaluator))
 
-;;; macro taken from: http://www.cliki.net/REPL
+;; Error message is sent to *error-output* and returned in eval-error pattern.
+(defun make-eval-error (quit err msg)
+  (let ((name (symbol-name (class-name (class-of err)))))
+    (write-string msg *error-output*)
+    `((eval-error) ,quit ,name ,msg)))
+
+;;; Based on macro taken from: http://www.cliki.net/REPL
 (defmacro handling-errors (&body body)
   `(catch 'maxima::return-from-debugger
     (handler-case (progn ,@body)
+       (cl-jupyter-user::quit (err)
+         (make-eval-error t err (format nil "~A" err)))
        (simple-condition (err)
-         (format *error-output* "~&~A: ~%" (class-name (class-of err)))
-         (apply (function format) *error-output*
-                (simple-condition-format-control   err)
-                (simple-condition-format-arguments err))
-         (format *error-output* "~&"))
+         (make-eval-error nil err
+           (apply #'format nil (simple-condition-format-control err)
+                               (simple-condition-format-arguments err))))
        (condition (err)
-         (format *error-output* "~&~A: ~%  ~S~%"
-                 (class-name (class-of err)) err)))))
+         (make-eval-error nil err (format nil "~A" err))))))
 
 (defun my-mread (input)
   (when (and (open-stream-p input) (peek-char nil input nil))
     (let ((maxima::*mread-prompt* "") (maxima::*prompt-on-read-hang*))
       (declare (special maxima::*mread-prompt* maxima::*prompt-on-read-hang*))
       (maxima::mread input nil))))
+
+(defun eval-error-p (result)
+  (and result (eq 'eval-error (caar result))))
+
+(defun quit-eval-error-p (result)
+  (and result (eq 'eval-error (caar result)) (cadr result)))
 
 (defun evaluate-code (evaluator code)
   (when maxima::$debug_evaluator
@@ -57,19 +68,22 @@ The history of evaluations is also saved by the evaluator.
          (input (make-string-input-stream (add-terminator code)))
          (results (do ((results '())
                        (code-to-eval (my-mread input) (my-mread input)))
-                    ((not code-to-eval) (reverse results))
+                      ((or (not code-to-eval) (quit-eval-error-p (last results)))
+                       (reverse results))
                     (when maxima::$debug_evaluator
                       (format t "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
                       (terpri))
-                    (let ((result (handling-errors
-                                   (let ((*standard-output* stdout)
-                                         (*error-output* stderr)
-                                         (*package* (find-package :maxima)))
-                                   (maxima::meval* code-to-eval)))))
+                    (let* ((*standard-output* stdout)
+                           (*error-output* stderr)
+                           (result (handling-errors
+                                     (let ((*package* (find-package :maxima)))
+                                       (maxima::with-$error
+                                         (maxima::meval* code-to-eval))))))
                       (when maxima::$debug_evaluator
                         (format t "[Evaluator] evaluated result: ~W~%" result)
                         (terpri))
-                      (setq maxima::$% (caddr result))
+                      (unless (eval-error-p result)
+                        (setq maxima::$% (caddr result)))
                       (setq results (cons result results))))))
     (vector-push results (evaluator-history-out evaluator))
     (values execution-count results

--- a/src/iopub.lisp
+++ b/src/iopub.lisp
@@ -56,6 +56,15 @@
                                      ("metadata" (jsown:new-js))))))
     (message-send (iopub-socket iopub) result-msg :key key)))
 
+(defun send-execute-error (iopub parent-msg execution-count ename evalue &key (key nil))
+  (let* ((result-msg (make-message parent-msg "error"
+                                   (jsown:new-js
+                                     ("execution_count" execution-count)
+                                     ("ename" ename)
+                                     ("evalue" evalue)
+                                     ("traceback" nil)))))
+    (message-send (iopub-socket iopub) result-msg :key key)))
+
 (defun send-stream (iopub parent-msg stream-name data &key (key nil))
   (let ((stream-msg (make-message parent-msg "stream"
                                   (jsown:new-js

--- a/src/iopub.lisp
+++ b/src/iopub.lisp
@@ -7,58 +7,58 @@
 |#
 
 (defclass iopub-channel ()
-  ((kernel :initarg :kernel :reader iopub-kernel)
-   (socket :initarg :socket :initform nil :accessor iopub-socket)))
+  ((kernel :initarg :kernel
+           :reader iopub-kernel)
+   (socket :initarg :socket
+           :initform nil
+           :accessor iopub-socket)))
 
 (defun make-iopub-channel (kernel)
-  (let ((socket (pzmq:socket (kernel-ctx kernel) :pub)))
-    (let ((iopub (make-instance 'iopub-channel
-                                :kernel kernel
-                                :socket socket)))
-      (let ((config (slot-value kernel 'config)))
-        (let ((endpoint (format nil "~A://~A:~A"
-                                  (config-transport config)
-                                  (config-ip config)
-                                  (config-iopub-port config))))
-          ;;(format t "[IOPUB] iopub endpoint is: ~A~%" endpoint)
-          (pzmq:bind socket endpoint)
+  (let* ((socket (pzmq:socket (kernel-ctx kernel) :pub))
+         (iopub (make-instance 'iopub-channel
+                               :kernel kernel
+                               :socket socket))
+         (config (slot-value kernel 'config))
+         (endpoint (format nil "~A://~A:~A"
+                           (config-transport config)
+                           (config-ip config)
+                           (config-iopub-port config))))
+    ; (format t "[IOPUB] iopub endpoint is: ~A~%" endpoint)
+    (pzmq:bind socket endpoint)
 	  (setf (slot-value kernel 'iopub) iopub)
-          iopub)))))
+    iopub))
 
 (defun send-status-starting (iopub session &key (key nil))
-  (let ((status-msg (make-orphan-message session "status"
+  (let ((status-msg (make-orphan-message session "status" '("status")
                                          (jsown:new-js
                                            ("execution_state" "starting")))))
-    (message-send (iopub-socket iopub) status-msg :identities '("status") :key key)))
+    (message-send (iopub-socket iopub) status-msg :key key)))
 
 (defun send-status-update (iopub parent-msg status &key (key nil))
-  (let ((status-content `((:execution--state . ,status))))
-    (let ((status-msg (make-message parent-msg "status"
-                                    (jsown:new-js
-                                      ("execution_state" status)))))
-      (message-send (iopub-socket iopub) status-msg :identities '("status") :key key))))
+  (let ((status-msg (make-message parent-msg "status"
+                                  (jsown:new-js
+                                    ("execution_state" status)))))
+      (message-send (iopub-socket iopub) status-msg :key key)))
 
 (defun send-execute-code (iopub parent-msg execution-count code &key (key nil))
   (let ((code-msg (make-message parent-msg "execute_input"
                                 (jsown:new-js
                                   ("code" code)
                                   ("execution_count" execution-count)))))
-    (message-send (iopub-socket iopub) code-msg :identities '("execute_input") :key key)))
-
+    (message-send (iopub-socket iopub) code-msg :key key)))
 
 (defun send-execute-result (iopub parent-msg execution-count result &key (key nil))
-  (let ((display-obj (display result)))
-    (let ((result-msg (make-message parent-msg "execute_result"
-                                    (jsown:new-js
-                                      ("execution_count" execution-count)
-                                      ("data" (display-object-data display-obj))
-                                      ("metadata" (jsown:new-js))))))
-      (message-send (iopub-socket iopub) result-msg :identities '("execute_result") :key key))))
+  (let* ((display-obj (display result))
+         (result-msg (make-message parent-msg "execute_result"
+                                   (jsown:new-js
+                                     ("execution_count" execution-count)
+                                     ("data" (display-object-data display-obj))
+                                     ("metadata" (jsown:new-js))))))
+    (message-send (iopub-socket iopub) result-msg :key key)))
 
 (defun send-stream (iopub parent-msg stream-name data &key (key nil))
-  (format t "~A~%" data)
   (let ((stream-msg (make-message parent-msg "stream"
                                   (jsown:new-js
                                     ("name" stream-name)
                                     ("text" data)))))
-    (message-send (iopub-socket iopub) stream-msg :identities `(,(format nil "stream.~W" stream-name)) :key key)))
+    (message-send (iopub-socket iopub) stream-msg :key key)))

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -47,32 +47,14 @@
 (example (concat-all 'string "" '("a" "b" "c" "d" "e"))
          => "abcde")
 
-(defun banner ()
-  (concat-all
-   'string ""
-   (join (format nil "~%")
-         '("                                 __________       "
-           "                                /         /.      "
-           "     .-----------------.       /_________/ |      "
-           "    /                 / |      |         | |      "
-           "   /+================+\\ |      | |====|  | |      "
-           "   ||cl-jupyter      || |      |         | |      "
-           "   ||                || |      | |====|  | |      "
-           "   ||* (fact 5)      || |      |         | |      "
-           "   ||120             || |      |   ___   | |      "
-           "   ||                || |      |  |166|  | |      "
-           "   ||                ||/@@@    |   ---   | |      "
-           "   \\+================+/    @   |_________|./.     "
-           "                         @           ..  ....'    "
-           "     ..................@      __.'. '  ''         "
-           "    /oooooooooooooooo//      ///                  "
-           "   /................//      /_/                   "
-           "   ------------------                             "
-           ""))))
-
-;; (format t (banner))
-
-
+(defun banner (stream)
+  (format stream (concatenate 'string
+                              "~A: an enhanced interactive Maxima REPL~%"
+                              "(Version ~A - Jupyter protocol v.~A)~%"
+                              "--> (C) 2014-2015 Frederic Peschanski (cf. LICENSE)~%")
+          +KERNEL-IMPLEMENTATION-NAME+
+          +KERNEL-IMPLEMENTATION-VERSION+
+          +KERNEL-PROTOCOL-VERSION+))
 
 (defclass kernel-config ()
   ((transport :initarg :transport :reader config-transport :type string)
@@ -86,13 +68,6 @@
    (key :initarg :key :reader kernel-config-key)))
 
 (defun kernel-start (connection-file-name)
-  (write-line "")
-  (format t "~A: an enhanced interactive Maxima REPL~%" +KERNEL-IMPLEMENTATION-NAME+)
-  (format t "(Version ~A - Jupyter protocol v.~A)~%"
-          +KERNEL-IMPLEMENTATION-VERSION+
-          +KERNEL-PROTOCOL-VERSION+)
-  (format t "--> (C) 2014-2015 Frederic Peschanski (cf. LICENSE)~%")
-  (write-line "")
   (format t "connection file = ~A~%" connection-file-name)
   (unless (stringp connection-file-name)
     (error "Wrong connection file argument (expecting a string)"))

--- a/src/user.lisp
+++ b/src/user.lisp
@@ -1,11 +1,15 @@
 (in-package #:cl-jupyter-user)
 
-(defclass cl-jupyter-quit-obj ()
+(define-condition quit (error)
   ()
-  (:documentation "A quit object for identifying a request for kernel shutdown."))
+  (:documentation "A quit condition for identifying a request for kernel shutdown.")
+  (:report (lambda (c stream))))
+
+(maxima::defmfun maxima::$quit ()
+  (error (make-condition 'quit)))
 
 (defun quit ()
-  (make-instance 'cl-jupyter-quit-obj))
+  (error (make-condition 'quit)))
 
 
 #|


### PR DESCRIPTION
This PR improves messaging a bit, captures Maxima errors and makes `quit` work.

- Store identities in message to avoid passing to every function.
- Remove buffer parameters since this is not part the Jupyter protocol and is not used anywhere.
- Only return `message` from `wire-deserialize`,
- Check signatures on received messages.
- Capture Maxima errors as conditions and send appropriate error message replies.
- Convert quit requests to a condition and capture using same mechanism.