### PR TITLE
Capture syntax errors and refactor kernel loop

### DIFF
--- a/src/channel.lisp
+++ b/src/channel.lisp
@@ -1,0 +1,25 @@
+(in-package #:cl-jupyter)
+
+(defclass channel ()
+  ((key :initarg :key
+        :reader channel-key)
+   (socket :initarg :socket
+           :reader channel-socket)))
+
+(defun make-channel (config socket port &key (class 'channel))
+  (let* ((key (config-key config))
+         (channel (make-instance class
+                                 :key key
+                                 :socket socket))
+         (endpoint (format nil "~A://~A:~A"
+                               (config-transport config)
+                               (config-ip config)
+                               port)))
+    (pzmq:bind socket endpoint)
+    channel))
+
+(defgeneric stop (ch)
+  (:documentation "Stop the channel."))
+
+(defmethod stop ((ch channel))
+  (pzmq:close (channel-socket ch)))

--- a/src/channel.lisp
+++ b/src/channel.lisp
@@ -4,22 +4,40 @@
   ((key :initarg :key
         :reader channel-key)
    (socket :initarg :socket
-           :reader channel-socket)))
+           :reader channel-socket)
+   (transport :initarg :transport
+              :reader channel-transport)
+   (ip :initarg :ip
+       :reader channel-ip)
+   (port :initarg :port
+         :reader channel-port)))
 
 (defun make-channel (config socket port &key (class 'channel))
-  (let* ((key (config-key config))
-         (channel (make-instance class
-                                 :key key
-                                 :socket socket))
-         (endpoint (format nil "~A://~A:~A"
-                               (config-transport config)
-                               (config-ip config)
-                               port)))
-    (pzmq:bind socket endpoint)
-    channel))
+  (make-instance class
+                 :key (config-key config)
+                 :socket socket
+                 :transport (config-transport config)
+                 :ip (config-ip config)
+                 :port port))
 
 (defgeneric stop (ch)
-  (:documentation "Stop the channel."))
+  (:documentation "Start the resource."))
+
+(defun start-channel (ch)
+  (pzmq:bind (channel-socket ch)
+             (format nil "~A://~A:~A"
+                         (channel-transport ch)
+                         (channel-ip ch)
+                         (channel-port ch))))
+
+(defmethod start ((ch channel))
+  (start-channel ch))
+
+(defgeneric stop (ch)
+  (:documentation "Stop the resource."))
+
+(defmethod stop-channel ((ch channel))
+  (pzmq:close (channel-socket ch)))
 
 (defmethod stop ((ch channel))
-  (pzmq:close (channel-socket ch)))
+  (stop-channel ch))

--- a/src/channel.lisp
+++ b/src/channel.lisp
@@ -13,9 +13,10 @@
        :type string)
    (port :initarg :port
          :reader channel-port
-         :type fixnum)))
+         :type fixnum))
+  (:documentation "Common channel class."))
 
-(defun make-channel (config socket port &key (class 'channel))
+(defun make-channel (class config socket port)
   (make-instance class
                  :key (config-key config)
                  :socket socket
@@ -27,6 +28,7 @@
   (:documentation "Start the resource."))
 
 (defun start-channel (ch)
+  (info "[~(~A~)] Starting...~%" (class-name (class-of ch)))
   (pzmq:bind (channel-socket ch)
              (format nil "~A://~A:~A"
                          (channel-transport ch)
@@ -40,6 +42,7 @@
   (:documentation "Stop the resource."))
 
 (defmethod stop-channel ((ch channel))
+  (info "[~(~A~)] Stopped.~%" (class-name (class-of ch)))
   (pzmq:close (channel-socket ch)))
 
 (defmethod stop ((ch channel))

--- a/src/channel.lisp
+++ b/src/channel.lisp
@@ -6,11 +6,14 @@
    (socket :initarg :socket
            :reader channel-socket)
    (transport :initarg :transport
-              :reader channel-transport)
+              :reader channel-transport
+              :type string)
    (ip :initarg :ip
-       :reader channel-ip)
+       :reader channel-ip
+       :type string)
    (port :initarg :port
-         :reader channel-port)))
+         :reader channel-port
+         :type fixnum)))
 
 (defun make-channel (config socket port &key (class 'channel))
   (make-instance class

--- a/src/display.lisp
+++ b/src/display.lisp
@@ -125,11 +125,7 @@ Lisp printer. In most cases this is enough but specializations are
   (if (and (plot-p value) (ends-with-p (caddr value) ext))
     (if base64
       (file-to-base64-string (caddr value))
-      ;; substitute spaces for tabs in SVG file; otherwise tabs seem
-      ;; to cause JSON heartburn. I suspect, without much evidence,
-      ;; that this is a bug in some JSON library or the other.
-      ;; Possibly the same bug: https://github.com/JuliaLang/IJulia.jl/issues/200
-      (substitute #\space #\tab (file-slurp (caddr value))))))
+      (read-string-file (caddr value)))))
 
 (defgeneric render-pdf (value)
   (:documentation "Render the VALUE as a PDF. The expected
@@ -143,13 +139,6 @@ Lisp printer. In most cases this is enough but specializations are
 
 (defmethod render-svg ((value t))
   (render-plot value ".svg" nil))
-
-;; nicked from: http://rosettacode.org/wiki/Read_entire_file#Common_Lisp
-(defun file-slurp (path)
-  (with-open-file (stream path)
-    (let ((data (make-string (file-length stream))))
-      (read-sequence data stream)
-      data)))
 
 (defgeneric render-json (value)
   (:documentation "Render the VALUE as a JSON document. This uses the MYJSON encoding

--- a/src/evaluator.lisp
+++ b/src/evaluator.lisp
@@ -11,8 +11,6 @@ The history of evaluations is also saved by the evaluator.
 
 |#
 
-(defparameter maxima::$debug_evaluator nil)
-
 (defclass evaluator ()
   ((kernel :initarg :kernel :reader evaluator-kernel)
    (history-in :initform (make-array 64 :fill-pointer 0 :adjustable t)
@@ -75,22 +73,16 @@ The history of evaluations is also saved by the evaluator.
   (handling-errors
     (let ((code-to-eval (my-mread input)))
       (when code-to-eval
-        (when maxima::$debug_evaluator
-          (format t "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
-          (terpri))
+        (info "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
         (let* ((*package* (find-package :maxima))
                (result (maxima::with-$error (maxima::meval* code-to-eval))))
+          (info "[Evaluator] evaluated result: ~W~%" result)
           (setq maxima::$% (caddr result))
-          (when maxima::$debug_evaluator
-            (format t "[Evaluator] evaluated result: ~W~%" result)
-            (terpri))
           result)))))
 
 (defun evaluate-code (evaluator code)
   (loop
-    initially (when maxima::$debug_evaluator
-                (format t "[Evaluator] unparsed input: ~W~%" code)
-                (terpri))
+    initially (info "[Evaluator] unparsed input: ~W~%" code)
               (vector-push code (evaluator-history-in evaluator))
     with *standard-output* = (make-string-output-stream)
     with *error-output* = (make-string-output-stream)

--- a/src/evaluator.lisp
+++ b/src/evaluator.lisp
@@ -69,17 +69,17 @@ The history of evaluations is also saved by the evaluator.
   (handling-errors
     (let ((code-to-eval (my-mread input)))
       (when code-to-eval
-        (info "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
+        (info "[evaluator] Parsed expression to evaluate: ~W~%" code-to-eval)
         (let* ((*package* (find-package :maxima))
                (result (maxima::with-$error (maxima::meval* code-to-eval))))
-          (info "[Evaluator] evaluated result: ~W~%" result)
+          (info "[evaluator] Evaluated result: ~W~%" result)
           (setq maxima::$% (caddr result))
           result)))))
 
 (defun evaluate-code (evaluator code)
   (iter
     (initially
-      (info "[Evaluator] unparsed input: ~W~%" code)
+      (info "[evaluator] Unparsed input: ~W~%" code)
       (vector-push code (evaluator-history-in evaluator)))
     (with *standard-output* = (make-string-output-stream))
     (with *error-output* = (make-string-output-stream))

--- a/src/evaluator.lisp
+++ b/src/evaluator.lisp
@@ -32,6 +32,13 @@ The history of evaluations is also saved by the evaluator.
     (write-string msg *error-output*)
     `((eval-error) ,quit ,name ,msg)))
 
+(define-condition maxima-syntax-error (error)
+  ((message :initarg :message
+            :reader maxima-syntax-error-message))
+  (:documentation "Maxima syntax error.")
+  (:report (lambda (condition stream)
+             (write-string (maxima-syntax-error-message condition) stream))))
+
 ;;; Based on macro taken from: http://www.cliki.net/REPL
 (defmacro handling-errors (&body body)
   `(catch 'maxima::return-from-debugger
@@ -57,34 +64,44 @@ The history of evaluations is also saved by the evaluator.
 (defun quit-eval-error-p (result)
   (and result (eq 'eval-error (caar result)) (cadr result)))
 
+(let ((old-mread-synerr #'maxima::mread-synerr))
+  (defun maxima::mread-synerr (&rest args)
+    (error (make-condition 'maxima-syntax-error :message
+      (with-output-to-string (*standard-output*)
+        (catch 'maxima::macsyma-quit
+          (apply old-mread-synerr args)))))))
+
+(defun read-and-eval (input)
+  (handling-errors
+    (let ((code-to-eval (my-mread input)))
+      (when code-to-eval
+        (when maxima::$debug_evaluator
+          (format t "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
+          (terpri))
+        (let* ((*package* (find-package :maxima))
+               (result (maxima::with-$error (maxima::meval* code-to-eval))))
+          (setq maxima::$% (caddr result))
+          (when maxima::$debug_evaluator
+            (format t "[Evaluator] evaluated result: ~W~%" result)
+            (terpri))
+          result)))))
+
 (defun evaluate-code (evaluator code)
-  (when maxima::$debug_evaluator
-    (format t "[Evaluator] unparsed input: ~W~%" code)
-    (terpri))
-  (vector-push code (evaluator-history-in evaluator))
-  (let* ((execution-count (length (evaluator-history-in evaluator)))
-         (stdout (make-string-output-stream))
-         (stderr (make-string-output-stream))
-         (input (make-string-input-stream (add-terminator code)))
-         (results (do ((results '())
-                       (code-to-eval (my-mread input) (my-mread input)))
-                      ((or (not code-to-eval) (quit-eval-error-p (last results)))
-                       (reverse results))
-                    (when maxima::$debug_evaluator
-                      (format t "[Evaluator] parsed expression to evaluate: ~W~%" code-to-eval)
-                      (terpri))
-                    (let* ((*standard-output* stdout)
-                           (*error-output* stderr)
-                           (result (handling-errors
-                                     (let ((*package* (find-package :maxima)))
-                                       (maxima::with-$error
-                                         (maxima::meval* code-to-eval))))))
-                      (when maxima::$debug_evaluator
-                        (format t "[Evaluator] evaluated result: ~W~%" result)
-                        (terpri))
-                      (unless (eval-error-p result)
-                        (setq maxima::$% (caddr result)))
-                      (setq results (cons result results))))))
-    (vector-push results (evaluator-history-out evaluator))
-    (values execution-count results
-            (get-output-stream-string stdout) (get-output-stream-string stderr))))
+  (loop
+    initially (when maxima::$debug_evaluator
+                (format t "[Evaluator] unparsed input: ~W~%" code)
+                (terpri))
+              (vector-push code (evaluator-history-in evaluator))
+    with *standard-output* = (make-string-output-stream)
+    with *error-output* = (make-string-output-stream)
+    with input = (make-string-input-stream (add-terminator code))
+    for result = (read-and-eval input) then (read-and-eval input)
+    while result
+    collect result into results
+    until (quit-eval-error-p result)
+    finally (vector-push results (evaluator-history-out evaluator))
+            (return
+              (values (length (evaluator-history-in evaluator))
+                      results
+                      (get-output-stream-string *standard-output*)
+                      (get-output-stream-string *error-output*)))))

--- a/src/heartbeat.lisp
+++ b/src/heartbeat.lisp
@@ -9,13 +9,14 @@
 (defclass hb-channel (channel)
   ((thread-id :initarg :thread-id
               :initform nil
-              :accessor hb-thread-id)))
+              :accessor hb-thread-id))
+  (:documentation "Heartbeat channel class."))
 
 (defun make-hb-channel (config ctx)
-  (make-channel config
+  (make-channel 'hb-channel
+                config
                 (pzmq:socket ctx :rep)
-                (config-hb-port config)
-                :class 'hb-channel))
+                (config-hb-port config)))
 
 (defmethod start ((hb hb-channel))
   (start-channel hb)
@@ -23,10 +24,10 @@
     (setf (hb-thread-id hb)
           (bordeaux-threads:make-thread
             (lambda ()
-              (info "[Heartbeat] thread started~%")
+              (info "[hb-channel] Thread starting...~%")
               (pzmq:proxy socket socket (cffi:null-pointer)))))))
 
 (defmethod stop ((hb hb-channel))
-  (info "[Heartbeat] thread stopped~%")
+  (info "[hb-channel] Thread stopped.~%")
   (bordeaux-threads:destroy-thread (hb-thread-id hb))
   (stop-channel hb))

--- a/src/heartbeat.lisp
+++ b/src/heartbeat.lisp
@@ -12,19 +12,21 @@
               :accessor hb-thread-id)))
 
 (defun make-hb-channel (config ctx)
-  (let* ((hb (make-channel config
-                           (pzmq:socket ctx :rep)
-                           (config-hb-port config)
-                           :class 'hb-channel))
-         (socket (channel-socket hb)))
+  (make-channel config
+                (pzmq:socket ctx :rep)
+                (config-hb-port config)
+                :class 'hb-channel))
+
+(defmethod start ((hb hb-channel))
+  (start-channel hb)
+  (let ((socket (channel-socket hb)))
     (setf (hb-thread-id hb)
           (bordeaux-threads:make-thread
             (lambda ()
               (info "[Heartbeat] thread started~%")
-              (pzmq:proxy socket socket (cffi:null-pointer)))))
-    hb))
+              (pzmq:proxy socket socket (cffi:null-pointer)))))))
 
 (defmethod stop ((hb hb-channel))
   (info "[Heartbeat] thread stopped~%")
   (bordeaux-threads:destroy-thread (hb-thread-id hb))
-  (pzmq:close (channel-socket hb)))
+  (stop-channel hb))

--- a/src/heartbeat.lisp
+++ b/src/heartbeat.lisp
@@ -1,0 +1,30 @@
+(in-package #:cl-jupyter)
+
+#|
+
+# The Heartbeat channel #
+
+|#
+
+(defclass hb-channel (channel)
+  ((thread-id :initarg :thread-id
+              :initform nil
+              :accessor hb-thread-id)))
+
+(defun make-hb-channel (config ctx)
+  (let* ((hb (make-channel config
+                           (pzmq:socket ctx :rep)
+                           (config-hb-port config)
+                           :class 'hb-channel))
+         (socket (channel-socket hb)))
+    (setf (hb-thread-id hb)
+          (bordeaux-threads:make-thread
+            (lambda ()
+              (info "[Heartbeat] thread started~%")
+              (pzmq:proxy socket socket (cffi:null-pointer)))))
+    hb))
+
+(defmethod stop ((hb hb-channel))
+  (info "[Heartbeat] thread stopped~%")
+  (bordeaux-threads:destroy-thread (hb-thread-id hb))
+  (pzmq:close (channel-socket hb)))

--- a/src/iopub.lisp
+++ b/src/iopub.lisp
@@ -23,7 +23,7 @@
                            (config-transport config)
                            (config-ip config)
                            (config-iopub-port config))))
-    ; (format t "[IOPUB] iopub endpoint is: ~A~%" endpoint)
+    (info "[IOPUB] iopub endpoint is: ~A~%" endpoint)
     (pzmq:bind socket endpoint)
 	  (setf (slot-value kernel 'iopub) iopub)
     iopub))

--- a/src/iopub.lisp
+++ b/src/iopub.lisp
@@ -17,11 +17,11 @@
 
 |#
 
-(defun send-status-starting (iopub session)
+(defun send-status (iopub session status)
   (message-send iopub
                 (make-orphan-message session "status" '("status")
                                      (jsown:new-js
-                                       ("execution_state" "starting")))))
+                                       ("execution_state" status)))))
 
 (defun send-status-update (iopub parent-msg status)
   (message-send iopub

--- a/src/iopub.lisp
+++ b/src/iopub.lisp
@@ -6,68 +6,56 @@
 
 |#
 
-(defclass iopub-channel ()
-  ((kernel :initarg :kernel
-           :reader iopub-kernel)
-   (socket :initarg :socket
-           :initform nil
-           :accessor iopub-socket)))
+(defun make-iopub-channel (config ctx)
+  (make-channel config
+                (pzmq:socket ctx :pub)
+                (config-iopub-port config)))
 
-(defun make-iopub-channel (kernel)
-  (let* ((socket (pzmq:socket (kernel-ctx kernel) :pub))
-         (iopub (make-instance 'iopub-channel
-                               :kernel kernel
-                               :socket socket))
-         (config (slot-value kernel 'config))
-         (endpoint (format nil "~A://~A:~A"
-                           (config-transport config)
-                           (config-ip config)
-                           (config-iopub-port config))))
-    (info "[IOPUB] iopub endpoint is: ~A~%" endpoint)
-    (pzmq:bind socket endpoint)
-	  (setf (slot-value kernel 'iopub) iopub)
-    iopub))
+#|
 
-(defun send-status-starting (iopub session &key (key nil))
-  (let ((status-msg (make-orphan-message session "status" '("status")
-                                         (jsown:new-js
-                                           ("execution_state" "starting")))))
-    (message-send (iopub-socket iopub) status-msg :key key)))
+# Message sending functions
 
-(defun send-status-update (iopub parent-msg status &key (key nil))
-  (let ((status-msg (make-message parent-msg "status"
-                                  (jsown:new-js
-                                    ("execution_state" status)))))
-      (message-send (iopub-socket iopub) status-msg :key key)))
+|#
 
-(defun send-execute-code (iopub parent-msg execution-count code &key (key nil))
-  (let ((code-msg (make-message parent-msg "execute_input"
-                                (jsown:new-js
-                                  ("code" code)
-                                  ("execution_count" execution-count)))))
-    (message-send (iopub-socket iopub) code-msg :key key)))
+(defun send-status-starting (iopub session)
+  (message-send iopub
+                (make-orphan-message session "status" '("status")
+                                     (jsown:new-js
+                                       ("execution_state" "starting")))))
 
-(defun send-execute-result (iopub parent-msg execution-count result &key (key nil))
-  (let* ((display-obj (display result))
-         (result-msg (make-message parent-msg "execute_result"
-                                   (jsown:new-js
-                                     ("execution_count" execution-count)
-                                     ("data" (display-object-data display-obj))
-                                     ("metadata" (jsown:new-js))))))
-    (message-send (iopub-socket iopub) result-msg :key key)))
+(defun send-status-update (iopub parent-msg status)
+  (message-send iopub
+                (make-message parent-msg "status"
+                              (jsown:new-js
+                                ("execution_state" status)))))
 
-(defun send-execute-error (iopub parent-msg execution-count ename evalue &key (key nil))
-  (let* ((result-msg (make-message parent-msg "error"
-                                   (jsown:new-js
-                                     ("execution_count" execution-count)
-                                     ("ename" ename)
-                                     ("evalue" evalue)
-                                     ("traceback" nil)))))
-    (message-send (iopub-socket iopub) result-msg :key key)))
+(defun send-execute-code (iopub parent-msg execution-count code)
+  (message-send iopub
+                (make-message parent-msg "execute_input"
+                              (jsown:new-js
+                                ("code" code)
+                                ("execution_count" execution-count)))))
 
-(defun send-stream (iopub parent-msg stream-name data &key (key nil))
-  (let ((stream-msg (make-message parent-msg "stream"
-                                  (jsown:new-js
-                                    ("name" stream-name)
-                                    ("text" data)))))
-    (message-send (iopub-socket iopub) stream-msg :key key)))
+(defun send-execute-result (iopub parent-msg execution-count result)
+  (message-send iopub
+                (make-message parent-msg "execute_result"
+                              (jsown:new-js
+                                ("execution_count" execution-count)
+                                ("data" (display-object-data (display result)))
+                                ("metadata" (jsown:new-js))))))
+
+(defun send-execute-error (iopub parent-msg execution-count ename evalue)
+  (message-send iopub
+                (make-message parent-msg "error"
+                              (jsown:new-js
+                                ("execution_count" execution-count)
+                                ("ename" ename)
+                                ("evalue" evalue)
+                                ("traceback" nil)))))
+
+(defun send-stream (iopub parent-msg stream-name data)
+  (message-send iopub
+                (make-message parent-msg "stream"
+                              (jsown:new-js
+                                ("name" stream-name)
+                                ("text" data)))))

--- a/src/iopub.lisp
+++ b/src/iopub.lisp
@@ -6,8 +6,13 @@
 
 |#
 
+(defclass iopub-channel (channel)
+  ()
+  (:documentation "IOPUB channel class."))
+
 (defun make-iopub-channel (config ctx)
-  (make-channel config
+  (make-channel 'iopub-channel
+                config
                 (pzmq:socket ctx :pub)
                 (config-iopub-port config)))
 

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -1,22 +1,36 @@
 (in-package #:cl-jupyter)
 
 (defclass kernel ()
-  ((config :initarg :config :reader kernel-config)
-   (ctx :initarg :ctx :reader kernel-ctx)
-   (shell :initarg :shell :initform nil :reader kernel-shell)
-   (stdin :initarg :stdin :initform nil :reader kernel-stdin)
-   (iopub :initarg :iopub :initform nil :reader kernel-iopub)
-   (session :initarg :session :reader kernel-session)
-   (evaluator :initarg :evaluator :initform nil :reader kernel-evaluator))
+  ((config :initarg :config
+           :reader kernel-config)
+   (ctx :initarg :ctx
+        :reader kernel-ctx)
+   (hb :initarg :hb
+       :reader kernel-hb)
+   (shell :initarg :shell
+          :reader kernel-shell)
+   (stdin :initarg :stdin
+          :reader kernel-stdin)
+   (iopub :initarg :iopub
+          :reader kernel-iopub)
+   (session :initarg :session
+            :reader kernel-session)
+   (evaluator :initarg :evaluator
+              :reader kernel-evaluator))
   (:documentation "Kernel state representation."))
 
 (defun make-kernel (config)
   (let ((ctx (pzmq:ctx-new))
-	(session-id (format nil "~W" (uuid:make-v4-uuid))))
+        (session-id (format nil "~W" (uuid:make-v4-uuid))))
     (make-instance 'kernel
                    :config config
                    :ctx ctx
-		   :session session-id)))
+                   :hb (make-hb-channel config ctx)
+                   :shell (make-shell-channel config ctx)
+                   :stdin (make-stdin-channel config ctx)
+                   :iopub (make-iopub-channel config ctx)
+                   :session session-id
+                   :evaluator (make-evaluator))))
 
 (defun get-argv ()
   ;; Borrowed from apply-argv, command-line-arguments.  Temporary solution (?)
@@ -65,56 +79,65 @@
    (control-port :initarg :control-port :reader config-control-port :type fixnum)
    (hb-port :initarg :hb-port :reader config-hb-port :type fixnum)
    (signature-scheme :initarg :signature-scheme :reader config-signature-scheme :type string)
-   (key :initarg :key :reader kernel-config-key)))
+   (key :initarg :key :reader config-key)))
+
+(defun make-kernel-config (connection-file-name)
+  (let ((config-js (jsown:parse (concat-all 'string "" (read-file-lines connection-file-name)))))
+    (make-instance 'kernel-config
+                   :transport (jsown:val config-js "transport")
+                   :ip (jsown:val config-js "ip")
+                   :shell-port (jsown:val config-js "shell_port")
+                   :stdin-port (jsown:val config-js "stdin_port")
+                   :iopub-port (jsown:val config-js "iopub_port")
+                   :control-port (jsown:val config-js "control_port")
+                   :hb-port (jsown:val config-js "hb_port")
+                   :signature-scheme (jsown:val config-js "signature_scheme")
+                   :key (let ((str-key (jsown:val config-js "key")))
+                          (if (string= str-key "")
+                              nil
+                              (babel:string-to-octets str-key :encoding :ASCII))))))
+
+(defmethod stop ((k kernel))
+  (stop (kernel-hb k))
+  (stop (kernel-iopub k))
+  (stop (kernel-shell k))
+  (stop (kernel-stdin k))
+  (pzmq:ctx-destroy (kernel-ctx k)))
 
 (defun kernel-start (connection-file-name)
   (info (banner nil))
   (info "[Kernel] connection file = ~A~%" connection-file-name)
   (unless (stringp connection-file-name)
     (error "[Kernel] Wrong connection file argument (expecting a string)"))
-  (let* ((config-js (jsown:parse (concat-all 'string "" (read-file-lines connection-file-name))))
-         (config (make-instance 'kernel-config
-                                :transport (jsown:val config-js "transport")
-                                :ip (jsown:val config-js "ip")
-                                :shell-port (jsown:val config-js "shell_port")
-                                :stdin-port (jsown:val config-js "stdin_port")
-                                :iopub-port (jsown:val config-js "iopub_port")
-                                :control-port (jsown:val config-js "control_port")
-                                :hb-port (jsown:val config-js "hb_port")
-                                :signature-scheme (jsown:val config-js "signature_scheme")
-                                :key (let ((str-key (jsown:val config-js "key")))
-                                       (if (string= str-key "")
-                                           nil
-                                           (babel:string-to-octets str-key :encoding :ASCII))))))
+  (let ((config (make-kernel-config connection-file-name)))
     (when (not (string= (config-signature-scheme config) "hmac-sha256"))
       ;; XXX: only hmac-sha256 supported
       (error "[Kernel] Signature scheme 'hmac-sha256' required, was provided ~S." (config-signature-scheme config)))
       ;;(inspect config)
-    (let* ((kernel (make-kernel config))
-           (evaluator (make-evaluator kernel))
-           (shell (make-shell-channel kernel))
-           (stdin (make-stdin-channel kernel))
-           (iopub (make-iopub-channel kernel))
-           (hb-socket (pzmq:socket (kernel-ctx kernel) :rep)) ;; Launch the hearbeat thread
-           (hb-endpoint (format nil "~A://~A:~A"
-                                (config-transport config)
-                                (config-ip config)
-                                (config-hb-port config)))
-           (hb-bind (pzmq:bind hb-socket hb-endpoint))
-           (heartbeat-thread-id (start-heartbeat hb-socket)))
-      ;; main loop
-      (unwind-protect
-           (progn
-             (info "[Kernel] Entering mainloop ...~%")
-             (shell-loop shell))
-        ;; clean up when exiting
-        (bordeaux-threads:destroy-thread heartbeat-thread-id)
-        (pzmq:close hb-socket)
-        (pzmq:close (iopub-socket iopub))
-        (pzmq:close (shell-socket shell))
-        (pzmq:close (stdin-socket stdin))
-        (pzmq:ctx-destroy (kernel-ctx kernel))
-        (info "[Kernel] Exiting mainloop.~%")))))
+    (iter
+      (with kernel = (make-kernel config))
+      (with iopub = (kernel-iopub kernel))
+      (with shell = (kernel-shell kernel))
+      (initially
+        (info "[Kernel] Entering mainloop ...~%")
+        (send-status-starting iopub (kernel-session kernel)))
+      (for msg = (message-recv shell))
+      (for msg-type = (jsown:val (message-header msg) "msg_type"))
+      (while
+        (cond ((equal msg-type "kernel_info_request")
+         (handle-kernel-info-request kernel msg))
+        ((equal msg-type "execute_request")
+         (handle-execute-request kernel msg))
+        ((equal msg-type "shutdown_request")
+         (handle-shutdown-request kernel msg))
+        ((equal msg-type "is_complete_request")
+         (handle-is-complete-request kernel msg))
+        (t
+         (warn "[Shell] message type '~A' not (yet ?) supported, skipping..." msg-type)
+         t)))
+      (finally-protected
+        (info "[Kernel] Exiting mainloop.~%")
+        (stop kernel)))))
 
 ;; This is the entry point for a saved lisp image created by
 ;; trivial-dump-core:save-executable or equivalent.
@@ -128,18 +151,139 @@
 (maxima::defmfun maxima::$kernel_start (connection-file-name)
   (kernel-start connection-file-name))
 
-(defun start-heartbeat (socket)
-  (let ((thread-id (bordeaux-threads:make-thread
-		    (lambda ()
-		      (info "[Heartbeat] thread started~%")
-		      (pzmq:proxy socket socket (cffi:null-pointer))))))
+#|
 
-    ;; XXX: without proxy
-    ;; (loop
-    ;; 	 (pzmq:with-message msg
-    ;; 	   (pzmq:msg-recv msg socket)
-    ;; 			;;(info "Heartbeat Received:~%")
-    ;; 	   (pzmq:msg-send msg socket)
-    ;; 			;;(info "  | message: ~A~%" msg)
-    ;; 	   ))))))
-    thread-id))
+
+### Message type: kernel_info_reply ###
+
+|#
+
+(defun handle-kernel-info-request (kernel msg)
+  (info "[Shell] handling 'kernel-info-request'~%")
+  (message-send (kernel-shell kernel)
+    (make-message msg "kernel_info_reply"
+      (jsown:new-js
+        ("protocol_version" (jsown:val (message-header msg) "version"))
+        ("implementation" +KERNEL-IMPLEMENTATION-NAME+)
+        ("implementation_version" +KERNEL-IMPLEMENTATION-VERSION+)
+        ("banner" (banner nil))
+        ("help_links"
+          (list
+            (jsown:new-js
+              ("text" "Maxima Reference Manual")
+              ("url" "http://maxima.sourceforge.net/docs/manual/maxima.html"))
+            (jsown:new-js
+              ("text" "Maxima Documentation")
+              ("url" "http://maxima.sourceforge.net/documentation.html"))))
+        ("language_info"
+          (jsown:new-js
+            ("name" "maxima")
+            ("version" maxima::*autoconf-version*)
+            ("mimetype" "text/x-maxima")
+            ("pygments_lexer" "maxima")
+            ("codemirror_mode" "maxima")))))))
+#|
+
+### Message type: execute_request ###
+
+|#
+
+(let (execute-request-kernel execute-request-msg)
+
+  (defun handle-execute-request (kernel msg)
+    (info "[Shell] handling 'execute_request'~%")
+    (let* ((shell (kernel-shell kernel))
+           (iopub (kernel-iopub kernel))
+           (content (message-content msg))
+           (code (jsown:val content "code")))
+      (send-status-update iopub msg "busy")
+      (setq execute-request-kernel kernel)
+      (setq execute-request-msg msg)
+      ;;(info "  ===> Code to execute = ~W~%" code)
+      (vbinds (execution-count results stdout stderr)
+              (evaluate-code (kernel-evaluator kernel) code)
+        ;(info "Execution count = ~A~%" execution-count)
+        ;(info "results = ~A~%" results)
+        ;(info "STDOUT = ~A~%" stdout)
+        ;(info "STDERR = ~A~%" stderr)
+        ;broadcast the code to connected frontends
+        (send-execute-code iopub msg execution-count code)
+        ;; send the stdout
+        (when (and stdout (> (length stdout) 0))
+              (send-stream iopub msg "stdout" stdout))
+        ;; send the stderr
+        (when (and stderr (> (length stderr) 0))
+              (send-stream iopub msg "stderr" stderr))
+        ;; send the results
+        (dolist (result results)
+          (cond ((eval-error-p result)
+                 (send-execute-error iopub msg execution-count (caddr result) (cadddr result)))
+                ((eq (caar result) 'maxima::displayinput)
+                 (send-execute-result iopub msg execution-count (caddr result)))))
+        ;; status back to idle
+        (send-status-update iopub msg "idle")
+        ;; send reply (control)
+        (let ((errors (remove-if-not #'eval-error-p results)))
+          (if errors
+            (let ((ename (format nil "~{~A~^, ~}" (mapcar #'caddr errors)))
+                  (evalue (format nil "~{~A~^, ~}" (mapcar #'cadddr errors))))
+              (send-execute-reply-error shell msg execution-count ename evalue))
+            (send-execute-reply-ok shell msg execution-count)))
+        ;; return t if there is no quit errors present
+        (notany #'quit-eval-error-p results))))
+
+  ;; Redefine RETRIEVE in src/macsys.lisp to make use of input-request/input-reply.
+  ;; MSG, FLAG, and PRINT? are declared special there, so be careful to
+  ;; refer to those symbols in the :maxima package.
+
+  (defun maxima::retrieve (maxima::msg maxima::flag &aux (maxima::print? nil))
+    (declare (special maxima::msg maxima::flag maxima::print?))
+    (or (eq maxima::flag 'maxima::noprint) (setq maxima::print? t))
+    (let* ((retrieve-prompt (cond ((not maxima::print?)
+                                   (setq maxima::print? t)
+                                   (format nil ""))
+                                  ((null maxima::msg)
+                                   (format nil ""))
+                                  ((atom maxima::msg)
+                                   (format nil "~A" maxima::msg))
+                                  ((eq maxima::flag t)
+                                   (format nil "~{~A~}" (cdr maxima::msg)))
+                                  (t
+                                   (maxima::aformat nil "~M" maxima::msg))))
+           (stdin (kernel-stdin execute-request-kernel)))
+      (send-input-request stdin execute-request-msg retrieve-prompt)
+      (let* ((msg (message-recv stdin))
+             (content (message-content msg))
+             (value (jsown:val content "value")))
+        (maxima::mread-noprompt (make-string-input-stream (add-terminator value)) nil)))))
+
+#|
+
+### Message type: shutdown_request ###
+
+|#
+
+(defun handle-shutdown-request (kernel msg)
+  (info "[Shell] handling 'shutdown_request'~%")
+  (let* ((shell (kernel-shell kernel))
+         (content (message-content msg))
+         (restart (jsown:val content "restart")))
+    (send-shutdown-reply shell msg restart)
+    nil))
+
+#|
+
+### Message type: is_complete_request ###
+
+|#
+
+(defun handle-is-complete-request (kernel msg)
+  (info "[Shell] handling 'is_complete_request'~%")
+  (let* ((shell (kernel-shell kernel))
+         (content (message-content msg))
+         (code (jsown:val content "code"))
+         (status (if (ends-with-terminator code)
+                     "complete"
+                     "incomplete")))
+    (send-is-complete-reply shell msg status)
+    t))

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -142,7 +142,7 @@
               ((equal msg-type "is_complete_request")
                (handle-is-complete-request kernel msg))
               (t
-               (warn "[Shell] message type '~A' not (yet ?) supported, skipping..." msg-type)
+               (warn "[Shell] message type '~A' not supported, skipping..." msg-type)
                t)))
       (finally-protected
         (info "[Kernel] Exiting mainloop.~%")
@@ -163,7 +163,7 @@
 #|
 
 
-### Message type: kernel_info_reply ###
+### Message type: kernel_info_request ###
 
 |#
 

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -88,7 +88,7 @@
                                            (babel:string-to-octets str-key :encoding :ASCII))))))
     (when (not (string= (config-signature-scheme config) "hmac-sha256"))
       ;; XXX: only hmac-sha256 supported
-      (error "Kernel only supports signature scheme 'hmac-sha256' (provided ~S)" (config-signature-scheme config)))
+      (error "[Kernel] Signature scheme 'hmac-sha256' required, was provided ~S." (config-signature-scheme config)))
       ;;(inspect config)
     (let* ((kernel (make-kernel config))
            (evaluator (make-evaluator kernel))

--- a/src/maxima-jupyter.asd
+++ b/src/maxima-jupyter.asd
@@ -6,19 +6,22 @@
   :depends-on (:pzmq
                :bordeaux-threads
                :uuid
-	       :babel
-	       :ironclad
-	       :cl-base64
-         :jsown)
+               :babel
+               :ironclad
+               :iterate
+               :cl-base64
+               :jsown)
   :serial t
   :components ((:file "packages")
                (:file "utils")
-	       (:file "config")
+               (:file "config")
+               (:file "channel")
+               (:file "heartbeat")
                (:file "message")
                (:file "shell")
                (:file "stdin")
-	       (:file "iopub")
-	       (:file "display")
-	       (:file "evaluator")
+               (:file "iopub")
+               (:file "display")
+               (:file "evaluator")
                (:file "user")
                (:file "kernel")))

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -181,13 +181,13 @@ The wire-deserialization part follows.
 (defun wire-deserialize (parts &key (key nil))
   (let ((delim-index (position +WIRE-IDS-MSG-DELIMITER+ parts :test  #'equal)))
     (when (not delim-index)
-      (error "no <IDS|MSG> delimiter found in message parts"))
+      (error "[Wire] No <IDS|MSG> delimiter found in message parts"))
     (let* ((identities (subseq parts 0 delim-index))
            (sig (nth (1+ delim-index) parts))
            (parts (subseq parts (+ 2 delim-index) (+ 6 delim-index)))
            (expected-sig (if key (message-signing key parts) "")))
       (unless (equal sig expected-sig)
-        (error "Signature mismatch in message"))
+        (error "[Wire] Signature mismatch in message"))
       (destructuring-bind (header parent-header metadata content) parts
         (make-instance 'message
                        :header (jsown:parse header)

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -219,7 +219,7 @@ The wire-deserialization part follows.
 	 (bordeaux-threads:acquire-lock *message-send-lock*)
 	 (let ((wire-parts (wire-serialize msg :key key)))
 	   ;;DEBUG>>
-	   ;;(format t "~%[Send] wire parts: ~W~%" wire-parts)
+	   ;;(info "~%[Send] wire parts: ~W~%" wire-parts)
 	   (dolist (part wire-parts)
 	     (pzmq:send socket part :sndmore t))
 	   (pzmq:send socket nil)))
@@ -235,7 +235,7 @@ The wire-deserialization part follows.
        (BABEL-ENCODINGS:INVALID-UTF8-STARTER-BYTE
            ()
          ;; if it's not utf-8 we try latin-1 (Ugly !)
-         (format t "[Recv]: issue with UTF-8 decoding~%")
+         (warn "[Recv]: issue with UTF-8 decoding~%")
          (cffi:foreign-string-to-lisp (pzmq:msg-data msg) :count (pzmq:msg-size msg) :encoding :latin-1)))
      (pzmq:getsockopt socket :rcvmore))))
 
@@ -245,9 +245,9 @@ The wire-deserialization part follows.
 		    (BABEL-ENCODINGS:INVALID-UTF8-STARTER-BYTE
 		     ()
 		     ;; if it's not utf-8 we try latin-1 (Ugly !)
-		     (format t "[Recv]: issue with UTF-8 decoding~%")
+		     (warn "[Recv]: issue with UTF-8 decoding~%")
 		     (pzmq:recv-string socket :encoding :latin-1)))
-    ;;(format t "[Shell]: received message part #~A: ~W (more? ~A)~%" part-num part more)
+    ;;(info "[Shell]: received message part #~A: ~W (more? ~A)~%" part-num part more)
     (if more
         (zmq-recv-list socket (cons part parts) (+ part-num 1))
         (reverse (cons part parts)))))
@@ -260,6 +260,6 @@ The wire-deserialization part follows.
 	 (bordeaux-threads:acquire-lock *message-recv-lock*)
 	 (let ((parts (zmq-recv-list socket)))
 	   ;;DEBUG>>
-	   ;;(format t "[Recv]: parts: ~A~%" (mapcar (lambda (part) (format nil "~W" part)) parts))
+	   ;;(info "[Recv]: parts: ~A~%" (mapcar (lambda (part) (format nil "~W" part)) parts))
 	   (wire-deserialize parts :key key)))
     (bordeaux-threads:release-lock *message-recv-lock*)))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -5,9 +5,8 @@
            #:*example-equal-predicate*
            #:example
            #:example-progn
-           #:*logg-enabled*
-           #:*logg-level*
-           #:logg
+           #:*info-enabled*
+           #:info
            #:vbinds
            #:afetch
            #:while

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -5,7 +5,6 @@
            #:*example-equal-predicate*
            #:example
            #:example-progn
-           #:*info-enabled*
            #:info
            #:vbinds
            #:afetch

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -7,8 +7,6 @@
            #:example-progn
            #:info
            #:vbinds
-           #:afetch
-           #:while
            #:add-terminator
            #:ends-with-p
            #:ends-with-terminator
@@ -18,7 +16,7 @@
            #:read-binary-file))
 
 (defpackage #:cl-jupyter
-  (:use #:cl #:fredo-utils)
+  (:use #:cl #:fredo-utils #:iterate)
   (:export
    #:display
    #:display-plain render-plain

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -6,182 +6,10 @@
 
 |#
 
-(defclass shell-channel ()
-  ((kernel :initarg :kernel
-           :reader shell-kernel)
-   (socket :initarg :socket
-           :initform nil
-           :accessor shell-socket)))
-
-
-(defun make-shell-channel (kernel)
-  (let* ((socket (pzmq:socket (kernel-ctx kernel) :router))
-         (shell (make-instance 'shell-channel
-                               :kernel kernel
-                               :socket socket))
-         (config (slot-value kernel 'config))
-         (endpoint (format nil "~A://~A:~A"
-                           (config-transport config)
-                           (config-ip config)
-                           (config-shell-port config))))
-         (info "[Shell] endpoint is: ~A~%" endpoint)
-    (pzmq:bind socket endpoint)
-    shell))
-
-(defun shell-loop (shell)
-  (let ((active t))
-    (info "[Shell] loop started~%")
-    (send-status-starting (kernel-iopub (shell-kernel shell)) (kernel-session (shell-kernel shell)) :key (kernel-key shell))
-    (while active
-      (let* ((msg (message-recv (shell-socket shell) :key (kernel-key shell)))
-             (msg-type (jsown:val (message-header msg) "msg_type")))
-        (cond ((equal msg-type "kernel_info_request")
-               (handle-kernel-info-request shell msg))
-              ((equal msg-type "execute_request")
-               (setf active (handle-execute-request shell msg)))
-              ((equal msg-type "shutdown_request")
-               (setf active (handle-shutdown-request shell msg)))
-              ((equal msg-type "is_complete_request")
-               (handle-is-complete-request shell msg))
-              (t (warn "[Shell] message type '~A' not (yet ?) supported, skipping..." msg-type)))))))
-
-#|
-
-### Message type: kernel_info_reply ###
-
-|#
-
-(defun kernel-key (shell)
-  (kernel-config-key (kernel-config (shell-kernel shell))))
-
-(defun handle-kernel-info-request (shell msg)
-  (info "[Shell] handling 'kernel-info-request'~%")
-  (let ((reply (make-message
-                msg "kernel_info_reply"
-                (jsown:new-js
-                  ("protocol_version" (jsown:val (message-header msg) "version"))
-                  ("implementation" +KERNEL-IMPLEMENTATION-NAME+)
-                  ("implementation_version" +KERNEL-IMPLEMENTATION-VERSION+)
-                  ("banner" (banner nil))
-                  ("help_links"
-                    (list
-                      (jsown:new-js
-                        ("text" "Maxima Reference Manual")
-                        ("url" "http://maxima.sourceforge.net/docs/manual/maxima.html"))
-                      (jsown:new-js
-                        ("text" "Maxima Documentation")
-                        ("url" "http://maxima.sourceforge.net/documentation.html"))))
-                  ("language_info"
-                    (jsown:new-js
-                      ("name" "maxima")
-                      ("version" maxima::*autoconf-version*)
-                      ("mimetype" "text/x-maxima")
-                      ("pygments_lexer" "maxima")
-                      ("codemirror_mode" "maxima")))))))
-    (message-send (shell-socket shell) reply :key (kernel-key shell))))
-
-#|
-
-### Message type: execute_request ###
-
-|#
-
-(let (execute-request-shell execute-request-msg)
-
-  (defun handle-execute-request (shell msg)
-    (info "[Shell] handling 'execute_request'~%")
-    (let* ((key (kernel-key shell))
-           (iopub (kernel-iopub (shell-kernel shell)))
-           (content (message-content msg))
-           (code (jsown:val content "code")))
-      (send-status-update (kernel-iopub (shell-kernel shell)) msg "busy" :key key)
-      (setq execute-request-shell shell)
-      (setq execute-request-msg msg)
-      ;;(info "  ===> Code to execute = ~W~%" code)
-      (vbinds (execution-count results stdout stderr)
-              (evaluate-code (kernel-evaluator (shell-kernel shell)) code)
-        ;(info "Execution count = ~A~%" execution-count)
-        ;(info "results = ~A~%" results)
-        ;(info "STDOUT = ~A~%" stdout)
-        ;(info "STDERR = ~A~%" stderr)
-        ;broadcast the code to connected frontends
-        (send-execute-code iopub msg execution-count code :key key)
-        ;; send the stdout
-        (when (and stdout (> (length stdout) 0))
-              (send-stream iopub msg "stdout" stdout :key key))
-        ;; send the stderr
-        (when (and stderr (> (length stderr) 0))
-              (send-stream iopub msg "stderr" stderr :key key))
-        ;; send the results
-        (dolist (result results)
-          (cond ((eval-error-p result)
-                 (send-execute-error iopub msg execution-count (caddr result) (cadddr result) :key key))
-                ((eq (caar result) 'maxima::displayinput)
-                 (send-execute-result iopub msg execution-count (caddr result) :key key))))
-        ;; status back to idle
-        (send-status-update iopub msg "idle" :key key)
-        ;; send reply (control)
-        (let ((errors (remove-if-not #'eval-error-p results)))
-          (if errors
-            (let ((ename (format nil "~{~A~^, ~}" (mapcar #'caddr errors)))
-                  (evalue (format nil "~{~A~^, ~}" (mapcar #'cadddr errors))))
-              (send-execute-reply-error shell msg execution-count ename evalue :key key))
-            (send-execute-reply-ok shell msg execution-count :key key)))
-        ;; return t if there is no quit errors present
-        (notany #'quit-eval-error-p results))))
-
-  ;; Redefine RETRIEVE in src/macsys.lisp to make use of input-request/input-reply.
-  ;; MSG, FLAG, and PRINT? are declared special there, so be careful to
-  ;; refer to those symbols in the :maxima package.
-
-  (defun maxima::retrieve (maxima::msg maxima::flag &aux (maxima::print? nil))
-    (declare (special maxima::msg maxima::flag maxima::print?))
-    (or (eq maxima::flag 'maxima::noprint) (setq maxima::print? t))
-    (let* ((retrieve-prompt (cond ((not maxima::print?)
-                                   (setq maxima::print? t)
-                                   (format nil ""))
-                                  ((null maxima::msg)
-                                   (format nil ""))
-                                  ((atom maxima::msg)
-                                   (format nil "~A" maxima::msg))
-                                  ((eq maxima::flag t)
-                                   (format nil "~{~A~}" (cdr maxima::msg)))
-                                  (t
-                                   (maxima::aformat nil "~M" maxima::msg))))
-           (kernel (shell-kernel execute-request-shell))
-           (stdin (kernel-stdin kernel))
-           (key (kernel-key execute-request-shell)))
-      (send-input-request stdin execute-request-msg retrieve-prompt :key key)
-      (let* ((msg (message-recv (stdin-socket stdin) :key key))
-             (content (message-content msg))
-             (value (jsown:val content "value")))
-        (maxima::mread-noprompt (make-string-input-stream (add-terminator value)) nil)))))
-
-#|
-
-### Message type: shutdown_request ###
-
-|#
-
-(defun handle-shutdown-request (shell msg)
-  (let* ((content (message-content msg))
-         (restart (jsown:val content "restart")))
-    (send-shutdown-reply shell msg restart :key (kernel-key shell))
-    nil))
-
-#|
-
-### Message type: is_complete_request ###
-
-|#
-
-(defun handle-is-complete-request (shell msg)
-  (let* ((content (message-content msg))
-         (code (jsown:val content "code"))
-         (status (if (ends-with-terminator code)
-                     "complete"
-                     "incomplete")))
-    (send-is-complete-reply shell msg status :key (kernel-key shell))))
+(defun make-shell-channel (config ctx)
+  (make-channel config
+                (pzmq:socket ctx :router)
+                (config-shell-port config)))
 
 #|
 
@@ -189,43 +17,33 @@
 
 |#
 
-(defun send-shutdown-reply (shell parent-msg restart &key (key nil))
-  (let ((msg (make-message parent-msg "shutdown_reply"
-                           (jsown:new-js
-                             ("restart" (if restart t :f))))))
-    (message-send (shell-socket shell) msg :key key)))
+(defun send-shutdown-reply (shell parent-msg restart)
+  (message-send shell
+                (make-message parent-msg "shutdown_reply"
+                              (jsown:new-js
+                                ("restart" (if restart t :f))))))
 
-(defun send-is-complete-reply (shell parent-msg status &key (key nil))
-  (let ((msg (make-message parent-msg "is_complete_reply"
-                           (jsown:new-js
-                             ("status" status)
-                             ("indent" "")))))
-    (message-send (shell-socket shell) msg :key key)))
+(defun send-is-complete-reply (shell parent-msg status)
+  (message-send shell
+                (make-message parent-msg "is_complete_reply"
+                              (jsown:new-js
+                                ("status" status)
+                                ("indent" "")))))
 
-(defun send-execute-reply-ok (shell parent-msg execution-count &key (key nil))
-  (let ((msg (make-message parent-msg "execute_reply"
-                           (jsown:new-js
-                             ("status" "ok")
-                             ("execution_count" execution-count)
-                             ("payload" '())))))
-    (message-send (shell-socket shell) msg :key key)))
+(defun send-execute-reply-ok (shell parent-msg execution-count)
+  (message-send shell
+                (make-message parent-msg "execute_reply"
+                              (jsown:new-js
+                                ("status" "ok")
+                                ("execution_count" execution-count)
+                                ("payload" '())))))
 
-(defun send-execute-reply-error (shell parent-msg execution-count ename evalue &key (key nil))
-  (let ((msg (make-message parent-msg "execute_reply"
-                           (jsown:new-js
-                             ("status" "error")
-                             ("execution_count" execution-count)
-                             ("ename" ename)
-                             ("evalue" evalue)
-                             ("traceback" nil)))))
-    (message-send (shell-socket shell) msg :key key)))
-
-#|
-
-## Message content ##
-
-|#
-
-(defclass message-content ()
-  ()
-  (:documentation "The base class of message contents."))
+(defun send-execute-reply-error (shell parent-msg execution-count ename evalue)
+  (message-send shell
+                (make-message parent-msg "execute_reply"
+                              (jsown:new-js
+                                ("status" "error")
+                                ("execution_count" execution-count)
+                                ("ename" ename)
+                                ("evalue" evalue)
+                                ("traceback" nil)))))

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -24,13 +24,13 @@
                            (config-transport config)
                            (config-ip config)
                            (config-shell-port config))))
-         ;; (format t "shell endpoint is: ~A~%" endpoint)
+         (info "[Shell] endpoint is: ~A~%" endpoint)
     (pzmq:bind socket endpoint)
     shell))
 
 (defun shell-loop (shell)
   (let ((active t))
-    (format t "[Shell] loop started~%")
+    (info "[Shell] loop started~%")
     (send-status-starting (kernel-iopub (shell-kernel shell)) (kernel-session (shell-kernel shell)) :key (kernel-key shell))
     (while active
       (let* ((msg (message-recv (shell-socket shell) :key (kernel-key shell)))
@@ -55,10 +55,7 @@
   (kernel-config-key (kernel-config (shell-kernel shell))))
 
 (defun handle-kernel-info-request (shell msg)
-  ;;(format t "[Shell] handling 'kernel-info-request'~%")
-  ;; status to busy
-  ;;(send-status-update (kernel-iopub (shell-kernel shell)) msg "busy" :key (kernel-key shell))
-  ;; for protocol version 5
+  (info "[Shell] handling 'kernel-info-request'~%")
   (let ((reply (make-message
                 msg "kernel_info_reply"
                 (jsown:new-js
@@ -81,10 +78,7 @@
                       ("mimetype" "text/x-maxima")
                       ("pygments_lexer" "maxima")
                       ("codemirror_mode" "maxima")))))))
-    (message-send (shell-socket shell) reply :key (kernel-key shell))
-    ;; status back to idle
-    ;;(send-status-update (kernel-iopub (shell-kernel shell)) msg "idle" :key (kernel-key shell))
-    ))
+    (message-send (shell-socket shell) reply :key (kernel-key shell))))
 
 #|
 
@@ -95,7 +89,7 @@
 (let (execute-request-shell execute-request-msg)
 
   (defun handle-execute-request (shell msg)
-    ;;(format t "[Shell] handling 'execute_request'~%")
+    (info "[Shell] handling 'execute_request'~%")
     (let* ((key (kernel-key shell))
            (iopub (kernel-iopub (shell-kernel shell)))
            (content (message-content msg))
@@ -103,13 +97,13 @@
       (send-status-update (kernel-iopub (shell-kernel shell)) msg "busy" :key key)
       (setq execute-request-shell shell)
       (setq execute-request-msg msg)
-      ;;(format t "  ===> Code to execute = ~W~%" code)
+      ;;(info "  ===> Code to execute = ~W~%" code)
       (vbinds (execution-count results stdout stderr)
               (evaluate-code (kernel-evaluator (shell-kernel shell)) code)
-        ;(format t "Execution count = ~A~%" execution-count)
-        ;(format t "results = ~A~%" results)
-        ;(format t "STDOUT = ~A~%" stdout)
-        ;(format t "STDERR = ~A~%" stderr)
+        ;(info "Execution count = ~A~%" execution-count)
+        ;(info "results = ~A~%" results)
+        ;(info "STDOUT = ~A~%" stdout)
+        ;(info "STDERR = ~A~%" stderr)
         ;broadcast the code to connected frontends
         (send-execute-code iopub msg execution-count code :key key)
         ;; send the stdout

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -6,8 +6,13 @@
 
 |#
 
+(defclass shell-channel (channel)
+  ()
+  (:documentation "SHELL channel class."))
+
 (defun make-shell-channel (config ctx)
-  (make-channel config
+  (make-channel 'shell-channel
+                config
                 (pzmq:socket ctx :router)
                 (config-shell-port config)))
 

--- a/src/stdin.lisp
+++ b/src/stdin.lisp
@@ -8,50 +8,19 @@ See: http://jupyter-client.readthedocs.org/en/latest/messaging.html#messages-on-
 
 |#
 
-(defclass stdin-channel ()
-  ((kernel :initarg :kernel
-           :reader stdin-kernel)
-   (socket :initarg :socket
-           :initform nil
-           :accessor stdin-socket)))
-
-(defun make-stdin-channel (kernel)
-  (let* ((socket (pzmq:socket (kernel-ctx kernel) :dealer))
-         (stdin (make-instance 'stdin-channel
-                               :kernel kernel
-                               :socket socket))
-         (config (slot-value kernel 'config))
-         (endpoint (format nil "~A://~A:~A"
-                               (config-transport config)
-                               (config-ip config)
-                               (config-stdin-port config))))
-    (info "[stdin] endpoint is: ~A~%" endpoint)
-    (pzmq:bind socket endpoint)
-    (setf (slot-value kernel 'stdin) stdin)
-    stdin))
+(defun make-stdin-channel (config ctx)
+  (make-channel config
+                (pzmq:socket ctx :dealer)
+                (config-stdin-port config)))
 
 #|
 
-### Message type: input_request ###
+# Message sending functions
 
 |#
 
-(defclass content-input-request (message-content)
-  ((prompt :initarg :prompt :type string)
-   (password :initarg :password :type boolean)))
-
-(defclass content-input-reply (message-content)
-  ((value :initarg :value :type string)))
-
-(defun handle-input-reply (stdin msg)
-  (info "[stdin] handling 'input_reply'~%")
-
-  ;; AT THIS POINT NEED TO HAND OFF VALUE TO ASKSIGN OR WHATEVER
-  ;; CAUSED INPUT_REQUEST TO BE SENT !!
-)
-
-(defun send-input-request (stdin parent-msg prompt &key (key nil))
-  (let ((message (make-message parent-msg "input_request"
-                               (jsown:new-js
-                                 ("prompt" prompt)))))
-    (message-send (stdin-socket stdin) message :key key)))
+(defun send-input-request (stdin parent-msg prompt)
+  (message-send stdin
+                (make-message parent-msg "input_request"
+                              (jsown:new-js
+                                ("prompt" prompt)))))

--- a/src/stdin.lisp
+++ b/src/stdin.lisp
@@ -25,7 +25,7 @@ See: http://jupyter-client.readthedocs.org/en/latest/messaging.html#messages-on-
                                (config-transport config)
                                (config-ip config)
                                (config-stdin-port config))))
-    (format t "stdin endpoint is: ~A~%" endpoint)
+    (info "[stdin] endpoint is: ~A~%" endpoint)
     (pzmq:bind socket endpoint)
     (setf (slot-value kernel 'stdin) stdin)
     stdin))
@@ -44,7 +44,7 @@ See: http://jupyter-client.readthedocs.org/en/latest/messaging.html#messages-on-
   ((value :initarg :value :type string)))
 
 (defun handle-input-reply (stdin msg)
-  (format t "[stdin] handling 'input_reply'~%")
+  (info "[stdin] handling 'input_reply'~%")
 
   ;; AT THIS POINT NEED TO HAND OFF VALUE TO ASKSIGN OR WHATEVER
   ;; CAUSED INPUT_REQUEST TO BE SENT !!

--- a/src/stdin.lisp
+++ b/src/stdin.lisp
@@ -8,8 +8,13 @@ See: http://jupyter-client.readthedocs.org/en/latest/messaging.html#messages-on-
 
 |#
 
+(defclass stdin-channel (channel)
+  ()
+  (:documentation "STDIN channel class."))
+
 (defun make-stdin-channel (config ctx)
-  (make-channel config
+  (make-channel 'stdin-channel
+                config
                 (pzmq:socket ctx :dealer)
                 (config-stdin-port config)))
 

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -14,7 +14,7 @@
 
   (defparameter *example-with-echo* nil))
 
-(defvar maxima::$kernel_info t)
+(defvar maxima::$kernel_info f)
 
 
 (defmacro example (expr arrow expected &key (warn-only nil))
@@ -105,9 +105,9 @@
 
 (defun read-string-file (filename)
   (with-open-file (stream filename)
-    (let ((str (make-array (file-length stream) :element-type 'character :fill-pointer t)))
-      (setf (fill-pointer str) (read-sequence str stream))
-      str)))
+    (let ((data (make-string (file-length stream))))
+      (read-sequence data stream)
+      data)))
 
 (defun file-to-base64-string (path)
   (cl-base64:usb8-array-to-base64-string (read-binary-file path)))

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -12,9 +12,9 @@
 
   (defparameter *example-equal-predicate* #'equal)
 
-  (defparameter *example-with-echo* nil)
+  (defparameter *example-with-echo* nil))
 
-  )
+(defvar maxima::$kernel_info nil)
 
 
 (defmacro example (expr arrow expected &key (warn-only nil))
@@ -60,16 +60,9 @@
       `(progn ,@body)
       (values)))
 
-(defmacro logg (level fmt &rest args)
-  "Log the passed ARGS using the format string FMT and its
- arguments ARGS."
-  (if (or (not *log-enabled*)
-          (< level *log-level*))
-      (values);; disabled
-      ;; when enabled
-      `(progn (format ,*log-out-stream* "[LOG]:")
-              (format ,*log-out-stream* ,fmt ,@args)
-              (format ,*log-out-stream* "~%"))))
+(defun info (&rest args)
+  (when maxima::$kernel_info
+    (apply #'format *debug-io* args)))
 
 (defmacro vbinds (binders expr &body body)
   "An abbreviation for MULTIPLE-VALUE-BIND."

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -14,7 +14,7 @@
 
   (defparameter *example-with-echo* nil))
 
-(defvar maxima::$kernel_info nil)
+(defvar maxima::$kernel_info t)
 
 
 (defmacro example (expr arrow expected &key (warn-only nil))
@@ -89,28 +89,6 @@
 (example (vbinds (a _ b _) (values 1 2 3 4)
            (cons a b))
          => '(1 . 3)) ;; without a warning
-
-
-(defun afetch (comp alist &key (test #'eql))
-  (let ((binding (assoc comp alist :test test)))
-    (if binding
-        (cdr binding)
-        (error "No such key: ~A" comp))))
-
-(defmacro while (condition &body body)
-  (let ((eval-cond-var (gensym "eval-cond-"))
-        (body-val-var (gensym "body-val-")))
-    `(flet ((,eval-cond-var () ,`,condition))
-       (do ((,body-val-var nil (progn ,@body)))
-           ((not (,eval-cond-var))
-            ,body-val-var)))))
-
-(example (let ((count 0))
-           (while (< count 10)
-             ;;(format t "~A " count)
-             (incf count)
-             count))
-         => 10)
 
 (defun read-file-lines (filename)
   (with-open-file (input filename)


### PR DESCRIPTION
This PR covers a lot of ground. I can try to break it up into multiple PRs if it is too much. 

Basically I started out trying to capture syntax errors (currently they crash the kernel) and ended up realizing that I was going to have to rework the evaluator loop thereby breaking the `debug_evaluator` flag since `*standard-output*` would be captured. So I did some overall refactoring and other bug fixing also. Below is a summary of the changes.

- Capture syntax errors by overriding `mread-synerr`.
- Create common `channel` class and move `key` along with everything that `channel` needs to operate into that class.
- Move all kernel references out of child classes and move the "shell" loop into the kernel since it needs access to kernel resources and settings.
- Add generic `start`/`stop` for kernel and channels.
- Move heartbeat thread management into `hb-channel`.
- Do all kernel initialization in `make-kernel`.
- Send `busy`/`idle` for all requests as required by Jupyter protocol.
- Add `recv-parts` which will fall-back on binary parts if decoding fails. This fixes a bug in the Jupyter notebook which appears to use a non-string identity on the first `kernel_info_request`.
- Add the `buffers` message part back. I was wrong, this is in the Jupyter spec, although only used by extensions. The buffers may be binary data.
- Use `iterate` package to simplify and clarify `evaluator` and `kernel` loops.
- Remove some unneeded functions and join `read-string-file` and `file-slurp`.