### PR TITLE
Use consistent naming of functions in maxima namespace

### DIFF
--- a/install-maxima-jupyter.py
+++ b/install-maxima-jupyter.py
@@ -71,7 +71,7 @@ KERNEL_SPEC = {
         args.maxima,
         '--very-quiet',
         '--preload-lisp={0}'.format(os.path.join(args.root, 'load-maxima-jupyter.lisp')),
-        '--batch-string=kernel_start("{connection_file}")$'
+        '--batch-string=jupyter_kernel_start("{connection_file}")$'
     ],
     "display_name": "Maxima",
     "language": "maxima"

--- a/src/additions.lisp
+++ b/src/additions.lisp
@@ -1,0 +1,85 @@
+(in-package #:maxima)
+
+#|
+
+This is the entry point for starting the kernel from within an existing Maxima
+session.
+
+|#
+
+(defmfun $jupyter_kernel_start (connection-file-name)
+  (maxima-jupyter::kernel-start connection-file-name))
+
+#|
+
+Convenience functions to return specific types from Lisp or Maxima.
+
+|#
+
+(defun jupyter-file (path &optional (display nil))
+  (maxima-jupyter::make-file-result path :display display))
+
+(defmfun $jupyter_file (path &optional (display nil))
+  (maxima-jupyter::make-file-result path :display display))
+
+(defun jupyter-inline (value mime-type &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type mime-type
+                                            :display display))
+
+(defmfun $jupyter_inline (value mime-type &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type mime-type
+                                            :display display))
+
+(defun jupyter-text (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :display display))
+
+(defmfun $jupyter_text (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :display display))
+
+(defun jupyter-html (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*html-mime-type*
+                                            :display display))
+
+(defmfun $jupyter_html (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*html-mime-type*
+                                            :display display))
+
+(defun jupyter-jpeg (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*jpeg-mime-type*
+                                            :display display))
+
+(defmfun $jupyter_jpeg (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*jpeg-mime-type*
+                                            :display display))
+
+(defun jupyter-latex (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*latex-mime-type*
+                                            :display display))
+
+(defmfun $jupyter_latex (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*latex-mime-type*
+                                            :display display))
+
+(defun jupyter-markdown (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*markdown-mime-type*
+                                            :display display))
+
+(defmfun $jupyter_markdown (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*markdown-mime-type*
+                                            :display display))
+
+(defun jupyter-png (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*png-mime-type*
+                                            :display display))
+
+(defmfun $jupyter_png (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*png-mime-type*
+                                            :display display))
+
+(defun jupyter-svg (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*svg-mime-type*
+                                            :display display))
+
+(defmfun $jupyter_svg (value &optional (display nil))
+  (maxima-jupyter::make-inline-result value :mime-type maxima-jupyter::*svg-mime-type*
+                                            :display display))

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -133,11 +133,6 @@
   (setq *read-default-float-format* 'double-float)
   (kernel-start (car (last (get-argv)))))
 
-;; This is the entry point for starting the kernel from within an existing
-;; Maxima session.
-(maxima::defmfun maxima::$kernel_start (connection-file-name)
-  (kernel-start connection-file-name))
-
 #|
 
 ### Message type: kernel_info_request ###

--- a/src/maxima-jupyter.asd
+++ b/src/maxima-jupyter.asd
@@ -25,4 +25,5 @@
                (:file "iopub")
                (:file "results")
                (:file "evaluator")
-               (:file "kernel")))
+               (:file "kernel")
+               (:file "additions")))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -17,23 +17,14 @@
            #:read-binary-file))
 
 (defpackage #:maxima-jupyter
-  (:nicknames #:mj)
   (:use #:cl #:fredo-utils #:iterate)
   (:export
-    #:file
-    #:html
-    #:jpeg
     #:kernel-start
     #:kernel-start-exec
-    #:latex
     #:make-error-result
     #:make-file-result
     #:make-inline-result
     #:make-lisp-result
-    #:make-maxima-result
-    #:markdown
-    #:png
-    #:svg
-    #:text))
+    #:make-maxima-result))
 
 (in-package #:maxima-jupyter)

--- a/src/results.lisp
+++ b/src/results.lisp
@@ -14,6 +14,7 @@ Standard MIME types
 (defvar *markdown-mime-type* "text/markdown")
 (defvar *plain-text-mime-type* "text/plain")
 (defvar *png-mime-type* "image/png")
+(defvar *pdf-mime-type* "application/pdf")
 (defvar *svg-mime-type* "image/svg+xml")
 
 
@@ -169,72 +170,6 @@ Standard MIME types
          value)
         ((not (eq 'no-output value))
          (make-instance 'sexpr-result :value value))))
-
-#|
-
-Convenience functions to return specific types from Lisp or Maxima.
-
-|#
-
-(defun file (path &optional (display nil))
-  (make-file-result path :display display))
-
-(maxima::defmfun maxima::$mj_file (path &optional (display nil))
-  (make-file-result path :display display))
-
-(defun text (value &optional (display nil))
-  (make-inline-result value :display display))
-
-(maxima::defmfun maxima::$mj_text (value &optional (display nil))
-  (make-inline-result value :display display))
-
-(defun html (value &optional (display nil))
-  (make-inline-result value :mime-type *html-mime-type*
-                            :display display))
-
-(maxima::defmfun maxima::$mj_html (value &optional (display nil))
-  (make-inline-result value :mime-type *html-mime-type*
-                            :display display))
-
-(defun jpeg (value &optional (display nil))
-  (make-inline-result value :mime-type *jpeg-mime-type*
-                            :display display))
-
-(maxima::defmfun maxima::$mj_jpeg (value &optional (display nil))
-  (make-inline-result value :mime-type *jpeg-mime-type*
-                            :display display))
-
-(defun latex (value &optional (display nil))
-  (make-inline-result value :mime-type *latex-mime-type*
-                            :display display))
-
-(maxima::defmfun maxima::$mj_latex (value &optional (display nil))
-  (make-inline-result value :mime-type *latex-mime-type*
-                            :display display))
-
-(defun markdown (value &optional (display nil))
-  (make-inline-result value :mime-type *markdown-mime-type*
-                            :display display))
-
-(maxima::defmfun maxima::$mj_markdown (value &optional (display nil))
-  (make-inline-result value :mime-type *markdown-mime-type*
-                            :display display))
-
-(defun png (value &optional (display nil))
-  (make-inline-result value :mime-type *png-mime-type*
-                            :display display))
-
-(maxima::defmfun maxima::$mj_png (value &optional (display nil))
-  (make-inline-result value :mime-type *png-mime-type*
-                            :display display))
-
-(defun svg (value &optional (display nil))
-  (make-inline-result value :mime-type *svg-mime-type*
-                            :display display))
-
-(maxima::defmfun maxima::$mj_svg (value &optional (display nil))
-  (make-inline-result value :mime-type *svg-mime-type*
-                            :display display))
 
 #|
 


### PR DESCRIPTION
This PR uses `jupyter_` as a prefix for all Maxima visible functions and `jupyter-` for Lisp visible functions in the `maxima` namespace. I put all of these functions into `additions.lisp`. If you like that structure we could move all the overridden Maxima functions into `overrides.lisp` along with some comments of why they had to be overridden to make things work.