### PR TITLE
Add automatic prompt detection and testing

### DIFF
--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -184,6 +184,7 @@
             ("name" "maxima")
             ("version" maxima::*autoconf-version*)
             ("mimetype" "text/x-maxima")
+            ("file_extension" ".mac")
             ("pygments_lexer" "maxima")
             ("codemirror_mode" "maxima")))))))
 
@@ -193,17 +194,26 @@
 
 |#
 
+(setq maxima::*prompt-prefix* (coerce '(#\Escape #\X) 'string))
+(setq maxima::*prompt-suffix* (coerce '(#\Escape #\\) 'string))
+
 (defun handle-execute-request (kernel msg)
   (info "[kernel] Handling 'execute_request'~%")
   (let* ((shell (kernel-shell kernel))
          (iopub (kernel-iopub kernel))
+         (stdin (kernel-stdin kernel))
          (*kernel* kernel)
          (*message* msg)
-         (*page-output* (make-string-output-stream))
          (*payload* (make-array 16 :adjustable t :fill-pointer 0))
+         (*page-output* (make-string-output-stream))
+         (*query-io* (make-stdin-stream stdin msg))
+         (*standard-input* *query-io*)
+         (maxima::$stdin *query-io*)
          (*error-output* (make-iopub-stream iopub msg "stderr"))
+         (maxima::$stderr *error-output*)
          (*standard-output* (make-iopub-stream iopub msg "stdout"))
          (*debug-io* *standard-output*)
+         (maxima::$stdout *standard-output*)
          (content (message-content msg))
          (code (jsown:val content "code")))
     (vbinds (execution-count results)

--- a/src/overrides-cl-info.lisp
+++ b/src/overrides-cl-info.lisp
@@ -8,7 +8,7 @@ cl-info.lisp Overrides
 
 #|
 
-display-items is overridden to make use of get-input and the pager for output.
+display-items is overridden to make use of the pager for output.
 
 |#
 
@@ -36,20 +36,11 @@ display-items is overridden to make use of get-input and the pager for output.
                 for prompt-count from 0
                 thereis (progn
                           (finish-output *debug-io*)
-                          ;; REPLACE the following with a call to get-input
-                          ;; (print-prompt prompt-count)
-                          ;; (force-output)
-                          ;; (clear-input)
-                          ;; (select-info-items
-                          ;;   (parse-user-choice nitems) items-list)))
-                          ;; BEGIN
-                          (let* ((prompt (with-output-to-string (*standard-output*)
-                                           (print-prompt prompt-count)))
-                                 (input (maxima-jupyter::get-input prompt))
-                                 (choice (with-input-from-string (*standard-input* input)
-                                           (parse-user-choice nitems))))
-                          (select-info-items choice items-list))))
-                          ;; END
+                          (print-prompt prompt-count)
+                          (finish-output)
+                          (clear-input)
+                          (select-info-items
+                            (parse-user-choice nitems) items-list)))
               (clear-input))
             items-list))
     (finish-output *debug-io*)

--- a/src/overrides.lisp
+++ b/src/overrides.lisp
@@ -2,12 +2,98 @@
 
 #|
 
-macdes.lisp Overrides
+init-cl.lisp Overrides
+
+to_lisp and to-maxima are overridden since we do not have true Maxima REPL. We
+set a flag and throw out of the current evaluation.
 
 |#
 
+(defun $to_lisp ()
+  (format t "~&Type (to-maxima) to restart, ($quit) to quit Maxima.~%")
+  ; REPLACE the following with a call to to-lisp.
+  ; (let ((old-debugger-hook *debugger-hook*))
+  ;   (catch 'to-maxima
+  ;     (unwind-protect
+	;    (maxima-read-eval-print-loop)
+	; (setf *debugger-hook* old-debugger-hook)
+	; (format t "Returning to Maxima~%")))))
+  ; BEGIN
+  (maxima-jupyter::to-lisp))
+  ; END
+
+(defun to-maxima ()
+  ; REPLACE the following with a call to to-maxima along with a message.
+  ; (throw 'to-maxima t))
+  ; BEGIN
+  (format t "Returning to Maxima~%")
+  (maxima-jupyter::to-maxima))
+  ; END
+
 
 #|
+
+mdebug.lisp Overrides
+
+break-dbm-loop is overridden to catch the Maxima result and to flush the output
+before *debug-io*.
+
+|#
+
+(defun break-dbm-loop (at)
+  (let* ((*quit-tags* (cons (cons *break-level* *quit-tag*) *quit-tags*))
+	 (*break-level* (if (not at) *break-level* (cons t *break-level*)))
+	 (*quit-tag* (cons nil nil))
+	 (*break-env* *break-env*)
+	 (*mread-prompt* "")
+	 (*diff-bindlist* nil)
+	 (*diff-mspeclist* nil)
+	 val)
+    (declare (special *mread-prompt*))
+    (and (consp at) (set-env at))
+    (cond ((null at)
+	   (break-frame 0 nil)))
+    (catch 'step-continue
+      (catch *quit-tag*
+	(unwind-protect
+	     (do () (())
+	       (format-prompt *debug-io* "~&~a"
+			      (format nil "~@[(~a:~a) ~]"
+				      (unless (stringp at) "dbm")
+				      (length *quit-tags*)))
+	       (finish-output *debug-io*)
+	       (setq val
+		     (catch 'macsyma-quit
+		       (let ((res (dbm-read *debug-io*  nil *top-eof* t)))
+			 (declare (special *mread-prompt*))
+			 (cond ((and (consp res) (keywordp (car res)))
+				(let ((value (break-call (car res)
+							 (cdr res)
+				                         'break-command)))
+				  (cond ((eq value :resume) (return)))))
+			       ((eq res *top-eof*)
+			        (funcall (get :top 'break-command)))
+			       (t
+				(setq $__ (nth 2 res))
+				(setq $% (meval* $__))
+				(setq $_ $__)
+				;; REPLACE the following with a call to send-result
+				;; (displa $%)))
+				;; BEGIN
+				(maxima-jupyter::send-result
+				  (maxima-jupyter::make-maxima-result
+				    (list (first res) (second res) $%)))))
+				;; END
+			 nil)))
+	       (and (eql val 'top)
+		    (throw-macsyma-top)))
+	  (restore-bindings))))))
+
+
+#|
+
+macdes.lisp Overrides
+
 
 $example is overridden so that input is sent as display_data and the output
 produced by meval will handled by displayed make-maxima-result.
@@ -82,14 +168,9 @@ produced by meval will handled by displayed make-maxima-result.
            (mtell (intl:gettext "example: ~M not found. 'example();' returns the list of known examples.~%") example)
            (return '$done)))))))
 
-
 #|
 
 mload.lisp Overrides
-
-|#
-
-#|
 
 batch is overridden to catch the demo flag and use the set_next_input payload
 to send the code to the client.
@@ -111,3 +192,37 @@ to send the code to the client.
               (mgrind (third expr) f)
               (write-char (if (eql (caar expr) 'displayinput) #\; #\$) f)))))
       (apply old-$batch (list filename demo)))))
+
+#|
+
+nparse.lisp Overrides
+
+mread-synerr is overridden so that a condition is created instead of a throw.
+The original is not included since we call it directly.
+
+|#
+
+(let ((old-mread-synerr #'mread-synerr))
+  (defun mread-synerr (&rest args)
+    (error (make-condition 'maxima-jupyter::maxima-syntax-error :message
+      (with-output-to-string (*standard-output*)
+        (catch 'macsyma-quit
+          (apply old-mread-synerr args)))))))
+
+#|
+
+suprv1.lisp Overrides
+
+$quit is overridden send a condition versus signally bye.
+
+|#
+
+
+(defmfun $quit ()
+  ;; REPLACE the following with a condition.
+  ;; (princ *maxima-epilog*)
+  ;; (bye)
+  ;; (mtell (intl:gettext "quit: No known quit function for this Lisp.~%")))
+  ;; BEGIN
+  (error (make-condition 'maxima-jupyter::quit)))
+  ;; END

--- a/src/results.lisp
+++ b/src/results.lisp
@@ -46,8 +46,9 @@ Standard MIME types
   (format nil "~S" value))
 
 (defun mexpr-to-text (value)
-  (with-output-to-string (*standard-output*)
-    (maxima::displa value)))
+  (string-trim '(#\Newline)
+               (with-output-to-string (*standard-output*)
+                 (maxima::displa value))))
 
 (defun mexpr-to-latex (value)
   (let ((env (maxima::get-tex-environment value)))

--- a/src/stdin.lisp
+++ b/src/stdin.lisp
@@ -29,3 +29,68 @@ See: http://jupyter-client.readthedocs.org/en/latest/messaging.html#messages-on-
                 (make-message parent-msg "input_request"
                               (jsown:new-js
                                 ("prompt" prompt)))))
+
+#|
+
+stdin-stream is a bidirectional Gray stream that interprets output as prompts
+and sends an input_request when finish output is called. This should work in
+most cases of *query-io* usage. Makes overloading y-or-no-p unnecessary.
+
+|#
+
+(defvar *stdin-stream-size* 1024)
+
+(defclass stdin-stream (trivial-gray-streams:fundamental-character-output-stream
+                        trivial-gray-streams:fundamental-character-input-stream)
+  ((channel :initarg :channel
+            :reader stdin-stream-channel)
+   (parent-msg :initarg :parent-msg
+               :reader stdin-stream-parent-msg)
+   (output :initarg :output
+           :initform (make-array *stdin-stream-size*
+                                 :fill-pointer 0
+                                 :adjustable t
+                                 :element-type 'character)
+           :reader stdin-stream-output)
+   (input :initarg :input
+          :initform (make-array *stdin-stream-size*
+                                :fill-pointer 0
+                                :adjustable t
+                                :element-type 'character)
+          :reader stdin-stream-input)))
+
+(defun make-stdin-stream (stdin parent-msg)
+  (make-instance 'stdin-stream :channel stdin
+                               :parent-msg parent-msg))
+
+(defmethod trivial-gray-streams:stream-write-char ((stream stdin-stream) char)
+  (vector-push-extend char (stdin-stream-output stream)))
+
+(defmethod trivial-gray-streams:stream-finish-output ((stream stdin-stream))
+  (with-slots (channel parent-msg output input) stream
+    (let ((trimmed-output (string-trim '(#\Newline) output)))
+      (unless (zerop (length trimmed-output))
+        (send-input-request channel parent-msg output)
+        (adjust-array output *stdin-stream-size* :fill-pointer 0))
+        (let ((value (jsown:val (message-content (message-recv channel)) "value")))
+          (adjust-array input (length value)
+                        :fill-pointer (length value)
+                        :initial-contents (reverse value))))))
+
+(defmethod trivial-gray-streams:stream-listen ((stream stdin-stream))
+  (> (length (stdin-stream-input stream)) 0))
+
+(defmethod trivial-gray-streams:stream-read-char ((stream stdin-stream))
+  (let ((input (stdin-stream-input stream)))
+    (if (zerop (length input))
+      :eof
+      (vector-pop input))))
+
+(defmethod trivial-gray-streams:stream-peek-char ((stream stdin-stream))
+  (let ((input (stdin-stream-input stream)))
+    (if (zerop (length input))
+      :eof
+      (elt input (- (length input) 1)))))
+
+(defmethod trivial-gray-streams:stream-unread-char ((stream stdin-stream) char)
+  (vector-push-extend char (stdin-stream-input stream)))

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,0 +1,92 @@
+import unittest
+import jupyter_kernel_test
+
+
+class MyKernelTests(jupyter_kernel_test.KernelTests):
+    # Required --------------------------------------
+
+    # The name identifying an installed kernel to run the tests against
+    kernel_name = "maxima"
+
+    # language_info.name in a kernel_info_reply should match this
+    language_name = "maxima"
+
+    # the normal file extension (including the leading dot) for this language
+    # checked against language_info.file_extension in kernel_info_reply
+    file_extension = ".mac"
+
+    # Optional --------------------------------------
+
+    # Code in the kernel's language to write "hello, world" to stdout
+    code_hello_world = 'print("hello, world");'
+
+    # code which should cause (any) text to be written to STDERR
+    code_stderr = 'printf(stderr, "test");'
+
+    # samples for testing code-completeness (used by console only)
+    # these samples should respectively be unambigiously complete statements
+    # (which should be executed on <enter>), incomplete statements or code
+    # which should be identified as invalid
+    complete_code_samples = [
+        'x;',
+        ':br foo',
+        ":lisp (mapcar #'car '((1 a) (2 b) (3 c)))",
+        '??erfc'
+    ]
+    incomplete_code_samples = [
+        'x',
+        ":lisp (mapcar #'car '((1 a) (2 b) (3 c))"
+    ]
+    invalid_code_samples = [
+        'foo(;'
+    ]
+
+    # Pager: code that should display something (anything) in the pager
+    code_page_something = "??erfc"
+
+    # code which should generate a (user-level) error in the kernel, and send
+    # a traceback to the client
+    code_generate_error = "error();"
+
+    # Samples of code which generate a result value (ie, some text
+    # displayed as Out[n])
+    code_execute_result = [
+        {'code': '6*7;', 'result': '42'}
+    ]
+
+    # Samples of code which should generate a rich display output, and
+    # the expected MIME type
+    code_display_data = [
+        {
+            'code': 'jupyter_html("<html/>", true);',
+            'mime': 'text/html'
+        },
+        {
+            'code': 'jupyter_latex("$$x$$", true);',
+            'mime': 'text/latex'
+        },
+        {
+            'code': 'jupyter_markdown("x", true);',
+            'mime': 'text/markdown'
+        },
+        {
+            'code': 'jupyter_svg("<svg/>", true);',
+            'mime': 'image/svg+xml'
+        },
+        {
+            'code': 'jupyter_text("x", true);',
+            'mime': 'text/plain'
+        }
+    ]
+
+    # def test_maxima_latex(self):
+    #     reply, output_msgs = self.execute_helper(code='solve(x^2+x+1=0,x);')
+    #     print(reply)
+    #     print(output_msgs)
+    #     self.assertEqual(output_msgs[0]['msg_type'], 'stream')
+    #     self.assertEqual(output_msgs[0]['content']['name'], 'stderr')
+    #     self.assertEqual(output_msgs[0]['content']['text'], 'oops\n')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/client.py
+++ b/tests/client.py
@@ -46,7 +46,7 @@ class MyKernelTests(jupyter_kernel_test.KernelTests):
 
     # code which should generate a (user-level) error in the kernel, and send
     # a traceback to the client
-    code_generate_error = "error();"
+    code_generate_error = ':lisp (maxima-jupyter::make-error-result "foo" "bar")'
 
     # Samples of code which generate a result value (ie, some text
     # displayed as Out[n])

--- a/tests/client.py
+++ b/tests/client.py
@@ -31,14 +31,14 @@ class MyKernelTests(jupyter_kernel_test.KernelTests):
         'x;',
         ':br foo',
         ":lisp (mapcar #'car '((1 a) (2 b) (3 c)))",
-        '??erfc'
+        '??erfc',
     ]
     incomplete_code_samples = [
         'x',
-        ":lisp (mapcar #'car '((1 a) (2 b) (3 c))"
+        ":lisp (mapcar #'car '((1 a) (2 b) (3 c))",
     ]
     invalid_code_samples = [
-        'foo(;'
+        'foo(;',
     ]
 
     # Pager: code that should display something (anything) in the pager
@@ -56,28 +56,22 @@ class MyKernelTests(jupyter_kernel_test.KernelTests):
 
     # Samples of code which should generate a rich display output, and
     # the expected MIME type
-    code_display_data = [
-        {
-            'code': 'jupyter_html("<html/>", true);',
-            'mime': 'text/html'
-        },
-        {
-            'code': 'jupyter_latex("$$x$$", true);',
-            'mime': 'text/latex'
-        },
-        {
-            'code': 'jupyter_markdown("x", true);',
-            'mime': 'text/markdown'
-        },
-        {
-            'code': 'jupyter_svg("<svg/>", true);',
-            'mime': 'image/svg+xml'
-        },
-        {
-            'code': 'jupyter_text("x", true);',
-            'mime': 'text/plain'
-        }
-    ]
+    code_display_data = [{
+        'code': 'jupyter_html("<html/>", true);',
+        'mime': 'text/html'
+    }, {
+        'code': 'jupyter_latex("$$x$$", true);',
+        'mime': 'text/latex'
+    }, {
+        'code': 'jupyter_markdown("x", true);',
+        'mime': 'text/markdown'
+    }, {
+        'code': 'jupyter_svg("<svg/>", true);',
+        'mime': 'image/svg+xml'
+    }, {
+        'code': 'jupyter_text("x", true);',
+        'mime': 'text/plain'
+    }]
 
     # def test_maxima_latex(self):
     #     reply, output_msgs = self.execute_helper(code='solve(x^2+x+1=0,x);')


### PR DESCRIPTION
This PR adds support for a STDIN channel stream that overrides `*query-io*` and `*standard-input*`. This makes it possible to detect input requests without overriding the internals of Maxima functions like `retrieve`. It also adds the beginning of a testing framework for the client side. Some unneeded functions are removed and all Maxima overrides are moved into `overrides.lisp`.

## Mechanism

The class `stdin-stream` looks for `finish-output` calls on `*query-io*` and interprets them as printed prompts which are used in an `input_request`. The read side of `*query-io*` then filled with the results. The `iopub-stream` assists by looking for ANSI SOS and ANSI ST which are used as prompt delimeters. It writes prompts to `*query-io*` causing an `input_request`. All read calls from `*standard-input*`, `*debug-io*` and `iopub-stream` are routed to `stdin-stream` also.

All of this makes `retrieve`, `$read`, the dbm-loop prompts and the Lisp functions such as `yes-or-no-p` work without overriding.