### PR TITLE
Display Tweaks

### DIFF
--- a/src/overrides.lisp
+++ b/src/overrides.lisp
@@ -55,7 +55,7 @@ tex-mlabel is overridden to use tag so that mlabel will show up correctly.
 (defun jupyter-mlabel (x l r)
   (tex (caddr x)
        (append l
-	       (if (cadr x)
+	       (if (and (cadr x) *display-labels-p*)
 		   (list (format nil "\\tag{$~A$}" (tex-stripdollar (cadr x))))
 		   nil))
        r 'mparen 'mparen))

--- a/src/results.lisp
+++ b/src/results.lisp
@@ -41,6 +41,12 @@ Standard MIME types
        (listp (car code))
        (eq (caar code) 'maxima::displayinput)))
 
+(defun mlabel-input-result-p (code)
+  (and (listp code)
+       (listp (car code))
+       (eq (caar code) 'maxima::mlabel)
+       (starts-with-p (string (second code)) (string maxima::$inchar))))
+
 (defun mtext-result-p (code)
   (and (listp code)
          (listp (car code))
@@ -102,10 +108,14 @@ Standard MIME types
 
 (defmethod render ((res mexpr-result))
   (let ((value (mexpr-result-value res)))
-    (jsown:new-js
-      (*plain-text-mime-type* (mexpr-to-text value))
-      (*latex-mime-type* (mexpr-to-latex value))
-      (*maxima-mime-type* (mexpr-to-maxima value)))))
+    (if (mlabel-input-result-p value)
+      (jsown:new-js
+        (*plain-text-mime-type* (mexpr-to-text value))
+        (*maxima-mime-type* (mexpr-to-maxima value)))
+      (jsown:new-js
+        (*plain-text-mime-type* (mexpr-to-text value))
+        (*latex-mime-type* (mexpr-to-latex value))
+        (*maxima-mime-type* (mexpr-to-maxima value))))))
 
 (defclass inline-result (result)
   ((value :initarg :value


### PR DESCRIPTION
This PR has some small tweaks for displaying Maxima expressions. `*display-labels-p*` is now respected when rendering LaTeX. LaTeX is also not generated for input labels. This makes the output from `example` more usable.