### PR TITLE
Add support for binder, repo2docker and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM base/archlinux:2018.12.01
+
+RUN pacman -Sy --noconfirm base-devel jupyter gnuplot maxima
+
+ARG NB_USER=mj
+ARG NB_UID=1000
+
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+RUN useradd --create-home --shell=/bin/false --uid=${NB_UID} ${NB_USER}
+
+WORKDIR ${HOME}/maxima-jupyter
+
+COPY . ${HOME}/maxima-jupyter
+COPY maxima.js /usr/lib/python3.7/site-packages/notebook/static/components/codemirror/mode/maxima
+COPY maxima_lexer.py /usr/lib/python3.7/site-packages/pygments/lexers
+RUN patch /usr/lib/python3.7/site-packages/notebook/static/components/codemirror/mode/meta.js codemirror-mode-meta-patch
+RUN patch /usr/lib/python3.7/site-packages/pygments/lexers/_mapping.py pygments-mapping-patch
+RUN chown -R ${NB_UID} ${HOME} && chgrp -R ${NB_USER} ${HOME}
+
+USER ${NB_USER}
+
+RUN curl -O https://beta.quicklisp.org/quicklisp.lisp
+RUN sbcl --load quicklisp.lisp --load docker-install-quicklisp.lisp
+RUN python install-maxima-jupyter.py --user --root=`pwd`
+RUN echo quit | jupyter-console --no-confirm-exit --kernel=maxima --ZMQTerminalInteractiveShell.kernel_timeout=240
+
+WORKDIR ${HOME}/maxima-jupyter/examples

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,42 @@
 # Maxima-Jupyter
 
+[![Binder][mybinder-badge]][mybinder]
+
 An enhanced interactive environment for the computer algebra system Maxima,
 based on CL-Jupyter, a Jupyter kernel for Common Lisp, by Frederic Peschanski.
 Thanks, Frederic!
 
-## Requirements
+This file describes the installation and usage of Maxima-Jupyter on a local
+machine, but you can try out Maxima-Jupyter without installing anything by
+clicking on the Binder badge above.
+
+## Examples
+
+- [MaximaJupyterExample.ipynb][] &mdash; General usage of Maxima from within
+  Jupyter Notebook.
+
+- [MaximaJupyterTalk.ipynb][] &mdash; My notes for a talk given to the Portland
+  Python User Group.
+
+- [Plots.ipynb][] &mdash; Usage of plotting facilities from within Jupyter
+  Notebook.
+
+These examples make use of [nbviewer][].
+You can submit a link to your own notebook to tell nbviewer to render it.
+
+Note that the Github notebook renderer (i.e., what you see if you click on a
+notebook file in the Github file browser) is currently (November 2018) somewhat
+suboptimal ([bug report][]); it renders math as plain text, not as typeset
+formulas.
+
+## Installation
+
+Maxima-Jupyter may be installed on a machine using a local installation, a
+[repo2docker][] installation, or via a Docker image.
+
+## Local Installation
+
+### Requirements
 
 To try Maxima-Jupyter you need :
 
@@ -52,7 +84,7 @@ To try Maxima-Jupyter you need :
    On debian-based systems, you can satisfy this requirement by installing
    the package `libczmq-dev`.
 
-## Installing Maxima-Jupyter
+### Installing Maxima-Jupyter
 
 First you must install Jupyter, then you can install Maxima-Jupyter.
 
@@ -82,7 +114,7 @@ into `/usr/local/share/jupyter/kernels/maxima/kernel.json`
 and a user installation copies `kernel.json`
 into `/home/robert/.local/share/jupyter/kernels/maxima/kernel.json`.
 
-### Method 1. Maxima-Jupyter binary executable installation
+#### Method 1. Maxima-Jupyter binary executable installation
 
 The first installation method is to create a binary executable image,
 as detailed in [make-maxima-jupyter-recipe.txt][].
@@ -100,7 +132,7 @@ For a user installation,
 python3 ./install-maxima-jupyter.py --exec=path/to/maxima-jupyter-image --user
 ```
 
-### Method 2. Maxima-Jupyter loadable source installation
+#### Method 2. Maxima-Jupyter loadable source installation
 
 The second installation method executes Maxima and then loads Maxima-Jupyter into Maxima.
 The advantange to this method is that the normal initialization behavior of Maxima,
@@ -130,24 +162,28 @@ If not specified, the command which launches Maxima is just `maxima`,
 therefore the first instance of `maxima` in the PATH environment variable
 is the one which is executed.
 
-## Installation on Arch/Manjaro
+#### Method 3. Installation on Arch/Manjaro
 
 The package for Arch Linux is [maxima-jupyter-git][]. Building and installing
 (including dependencies) can be accomplished with:
 
-    yaourt -Sy maxima-jupyter-git
+```sh
+yaourt -Sy maxima-jupyter-git
+```
 
 Alternatively use ``makepkg``:
 
-    curl -L -O https://aur.archlinux.org/cgit/aur.git/snapshot/maxima-jupyter-git.tar.gz
-    tar -xvf maxima-jupyter-git.tar.gz
-    cd maxima-jupyter-git
-    makepkg -Csri
+```sh
+curl -L -O https://aur.archlinux.org/cgit/aur.git/snapshot/maxima-jupyter-git.tar.gz
+tar -xvf maxima-jupyter-git.tar.gz
+cd maxima-jupyter-git
+makepkg -Csri
+```
 
 Please consult the [Arch Wiki][] for more information regarding installing
 packages from the AUR.
 
-## Code Highlighting Installation
+### Code Highlighting Installation
 
 Highlighting Maxima code is handled by CodeMirror in the notebook
 and Pygments in HTML export.
@@ -163,11 +199,19 @@ Pygments installation directory, copy [maxima_lexer.py][] to that directory, and
 update `lexers/_mapping.py` as shown in [pygments-mapping-patch][]. Yes, this is
 pretty painful too.
 
-## Running Maxima-Jupyter
+### Running Maxima-Jupyter
 
-### Console mode
+Maxima-Jupyter may be run from a local installation in console mode by the following.
 
-    jupyter console --kernel=maxima
+```sh
+jupyter console --kernel=maxima
+```
+
+Notebook mode is initiated by the following.
+
+```sh
+jupyter notebook
+```
 
 When you enter stuff to be evaluated, you must include the usual trailing
 semicolon or dollar sign:
@@ -179,28 +223,41 @@ Out[1]: 42
 In [2]:
 ```
 
-### Notebook mode
+## repo2docker Usage
 
-    jupyter notebook
+Maxima-Jupyter may be run as a Docker image managed by repo2docker which will
+fetch the current code from GitHub and handle all the details of running the
+Jupyter Notebook server.
 
+First you need to install repo2docker (`sudo` may be required)
 
-## Notebook Examples
+```sh
+pip install jupyter-repo2docker
+```
 
-- [MaximaJupyterExample.ipynb][] &mdash; General usage of Maxima from within
-  Jupyter Notebook.
+Once repo2docker is installed then the following will build and start the
+server. Directions on accessing the server will be displayed once the image
+is built.
 
-- [MaximaJupyterTalk.ipynb][] &mdash; My notes for a talk given to the Portland
-  Python User Group.
+```sh
+jupyter-repo2docker --user-id=1000 --user-name=mj https://github.com/robert-dodier/maxima-jupyter
+```
 
-- [Plots.ipynb][] &mdash; Usage of plotting facilities from within Jupyter
-  Notebook.
+## Docker Image
 
-These examples make use of [nbviewer][].
-You can submit a link to your own notebook to tell nbviewer to render it.
+A Docker image of Maxima-Jupyter may be built using the following command
+(`sudo` may be required). This image is based on the docker image
+`base/archlinux`.
 
-Note that the Github notebook renderer (i.e., what you see if you click on
-a notebook file in the Github file browser) is currently (November 2018)
-somewhat suboptimal ([bug report][]); it renders math as plain text, not as typeset formulas.
+```sh
+docker build --tag=maxima-jupyter .
+```
+
+After the image is built the console may be run with
+
+```sh
+docker run -it maxima-jupyter jupyter console --kernel=maxima
+```
 
 ----
 
@@ -213,7 +270,7 @@ robert-dodier @ github
 <!--refs-->
 
 [Arch Wiki]: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages
-[nbviewer]: http://nbviewer.jupyter.org
+[Bordeaux Threads project description]: https://common-lisp.net/project/bordeaux-threads/
 [bug report]: https://github.com/jupyter/notebook/issues/1962
 [codemirror-mode-meta-patch]: https://github.com/robert-dodier/maxima-jupyter/blob/master/codemirror-mode-meta-patch
 [make-maxima-jupyter-recipe.txt]: https://github.com/robert-dodier/maxima-jupyter/blob/master/make-maxima-jupyter-recipe.txt
@@ -222,7 +279,10 @@ robert-dodier @ github
 [maxima.js]: https://github.com/robert-dodier/maxima-jupyter/blob/master/maxima.js
 [MaximaJupyterExample.ipynb]: http://nbviewer.jupyter.org/github/robert-dodier/maxima-jupyter/blob/master/examples/MaximaJupyterExample.ipynb
 [MaximaJupyterTalk.ipynb]: http://nbviewer.jupyter.org/github/robert-dodier/maxima-jupyter/blob/master/examples/MaximaJupyterTalk.ipynb
+[mybinder-badge]: https://mybinder.org/badge_logo.svg
+[mybinder]: https://mybinder.org/v2/gh/robert-dodier/maxima-jupyter/master
+[nbviewer]: http://nbviewer.jupyter.org
 [Plots.ipynb]: http://nbviewer.jupyter.org/github/robert-dodier/maxima-jupyter/blob/master/examples/Plots.ipynb
 [pygments-mapping-patch]: https://github.com/robert-dodier/maxima-jupyter/blob/master/pygments-mapping-patch
 [Quicklisp]: http://www.quicklisp.org
-[Bordeaux Threads project description]: https://common-lisp.net/project/bordeaux-threads/
+[repo2docker]: https://repo2docker.readthedocs.io/en/latest/

--- a/docker-install-quicklisp.lisp
+++ b/docker-install-quicklisp.lisp
@@ -1,0 +1,4 @@
+(quicklisp-quickstart:install)
+(ql-util:without-prompting
+  (ql:add-to-init-file))
+(quit)


### PR DESCRIPTION
This PR adds support for mybinder.org and local usage of repo2docker along with some basic Docker instructions should someone want to build their own image.

I've reworked the README a bit with some instructions, which could probably be expanded a bit. Please note that the binder badge will not work until this PR is merged. Until then https://mybinder.org/v2/gh/yitzchak/maxima-jupyter/binder will start a binder on this branch.

This resolves #9 and #43.

Thanks to @alessandro-dibella-rockalltech and @psychemedia for your work. It helped out a lot!