### PR TITLE
Add override for print

### DIFF
--- a/src/overrides.lisp
+++ b/src/overrides.lisp
@@ -270,3 +270,17 @@ plot is inside of a block.
     (when (maxima-jupyter::plot-p value)
       (jupyter-file (third value) t))
     value))
+
+#|
+
+$print is overridden so that math is displayed inline.
+
+|#
+
+(defover $print (orig &rest args)
+  (jupyter:latex
+    (format nil "~{~a~^ ~}"
+                (mapcar (lambda (arg) (if (stringp arg) arg (format nil "\\(~A\\)" ($tex1 arg))))
+                        args))
+    t)
+  (car (last args)))


### PR DESCRIPTION
Fixes #53.

Please note that inline math markers are inserted manually.