### PR TITLE
Dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,38 @@
 FROM archlinux/base
 
-RUN pacman -Sy --noconfirm base-devel jupyter gnuplot maxima
-
 ARG NB_USER=mj
 ARG NB_UID=1000
 
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 
-RUN useradd --create-home --shell=/bin/false --uid=${NB_UID} ${NB_USER}
+#RUN echo bust cache
+RUN pacman -Syu --noconfirm base-devel jupyter gnuplot maxima && \
+    useradd --create-home --shell=/bin/false --uid=${NB_UID} ${NB_USER}
 
 WORKDIR ${HOME}/maxima-jupyter
 
 COPY . ${HOME}/maxima-jupyter
 COPY maxima.js /usr/lib/python3.7/site-packages/notebook/static/components/codemirror/mode/maxima
 COPY maxima_lexer.py /usr/lib/python3.7/site-packages/pygments/lexers
-RUN patch /usr/lib/python3.7/site-packages/notebook/static/components/codemirror/mode/meta.js codemirror-mode-meta-patch
-RUN patch /usr/lib/python3.7/site-packages/pygments/lexers/_mapping.py pygments-mapping-patch
-RUN chown -R ${NB_UID} ${HOME} && chgrp -R ${NB_USER} ${HOME}
+
+RUN patch /usr/lib/python3.7/site-packages/notebook/static/components/codemirror/mode/meta.js codemirror-mode-meta-patch && \
+    patch /usr/lib/python3.7/site-packages/pygments/lexers/_mapping.py pygments-mapping-patch && \
+    chown -R ${NB_UID} ${HOME} && chgrp -R ${NB_USER} ${HOME}
 
 USER ${NB_USER}
 
-RUN curl -O https://beta.quicklisp.org/quicklisp.lisp
-RUN sbcl --load quicklisp.lisp --load docker-install-quicklisp.lisp
-RUN python install-maxima-jupyter.py --user --root=`pwd`
-RUN echo quit | jupyter-console --no-confirm-exit --kernel=maxima --ZMQTerminalInteractiveShell.kernel_timeout=240
+RUN curl -O https://beta.quicklisp.org/quicklisp.lisp && \
+    sbcl --load quicklisp.lisp --load docker-install-quicklisp.lisp && \
+    python install-maxima-jupyter.py --user --root=`pwd` && \
+    echo quit | jupyter-console --no-confirm-exit --kernel=maxima --ZMQTerminalInteractiveShell.kernel_timeout=240
 
+USER root
+RUN pacman -Scc --noconfirm
+
+USER ${NB_USER}
 WORKDIR ${HOME}/maxima-jupyter/examples
+
+EXPOSE 8888
+CMD ["console", "--kernel=maxima"]
+ENTRYPOINT ["jupyter"]

--- a/Readme.md
+++ b/Readme.md
@@ -247,17 +247,56 @@ jupyter-repo2docker --user-id=1000 --user-name=mj https://github.com/robert-dodi
 
 A Docker image of Maxima-Jupyter may be built using the following command
 (`sudo` may be required). This image is based on the docker image
-`base/archlinux`.
+`archlinux/base`.
 
 ```sh
 docker build --tag=maxima-jupyter .
 ```
-
-After the image is built the console may be run with
+If you'd like to build with a different user than the default (`mj`), you may
+override it with the following:
 
 ```sh
-docker run -it maxima-jupyter jupyter console --kernel=maxima
+docker build --build-arg NB_USER=alice --tag=maxima-jupyter .
 ```
+
+After the image is built the container may be run with:
+
+```sh
+docker run -it maxima-jupyter
+```
+
+The `Dockerfile` makes use of the `ENTRYPOINT` command; the default behaviour
+executes the `jupyter` binary with the arguments `console --kernel=maxima`. 
+
+If you'd like to run using Juypter's notebook web server, you may do the
+following to override the default use of `console`:
+
+```sh
+docker run -it \
+    -v `pwd`/notebooks:/home/USER/maxima-jupyter/examples \
+    -p 8888:8888 \
+    maxima-jupyter \
+    notebook --ip=0.0.0.0 --port=8888
+```
+
+where the last line is the set of arguments to `jupyter` that cause it to run
+in the notebook server mode.
+
+To run the Bash shell on the container, just override the entry point:
+
+```sh
+docker run -it --entrypoint=bash maxima-jupyter
+``` 
+
+If you cannot build the Docker image, you may use a 
+[pre-built one](https://hub.docker.com/r/calyau/maxima-jupyter)
+by subsituting the Docker image name `maxima-jupyter` in the above `docker`
+commands with `calyau/maxima-jupyter`. Note that the default user on the
+`calyau` image is not `mj`, but is rather `oubiwann`.
+
+Additional examples of notebooks created using this mode have been created
+here (taken from the Maxima tutorial):
+[https://github.com/calyau/maxima-tutorial-notebooks](https://github.com/calyau/maxima-tutorial-notebooks).
 
 ----
 


### PR DESCRIPTION
I've introduced some cleanup that does two things:
1. reduces the number of container layers
1. removes the package cache from the guest file system

Both of these reduce the overall image size.

Additionally, I've changed the image to use `ENTRYPOINT`, making the default usage simpler as well as reducing the number of commands necessary for running `jupyter` in other modes (`ENTRYPOINT` essentially lets you treat your Docker container like your executable). I've updated the README to provide clarity around this.

Finally, two other bits have been provided outside of this repo, for the benefit of users:
* a pre-built Docker image is available [here](https://hub.docker.com/r/calyau/maxima-jupyter) for users who don't/can't have a local copy of maxima-jupyter on their machines
* a handful of Maxima tutorial notebooks have been made available [here](https://github.com/calyau/maxima-tutorial-notebooks)

Links to these have been added to the README.