### PR TITLE
Fixed issue #68: Maxima Syntax Highlighting hangs when '$' is entered.

### DIFF
--- a/maxima.js
+++ b/maxima.js
@@ -57,6 +57,10 @@ CodeMirror.defineMode('maxima', function(_config, _parserConfig) {
       }
     }
 
+    if (ch === '$') {
+        return 'punctuation';
+    }
+
     // go back one character
     stream.backUp(1);
 

--- a/src/overrides-cl-info.lisp
+++ b/src/overrides-cl-info.lisp
@@ -54,6 +54,6 @@ display-items is overridden to make use of the pager for output.
 		     ;; BEGIN
 		     (format (or jupyter:*page-output* t) "~A~%~%" doc)
 		     ;; END
-		     (format t "Unable to find documentation for `~A'.~%~
+		     (format t "Unable to find documentation for `~A'.~%
                                 Possible bug maxima-index.lisp or build_index.pl?~%"
 			     (first (second item)))))))))


### PR DESCRIPTION
Hi Robert,

here's the proposed fix for issue [#68](https://github.com/robert-dodier/maxima-jupyter/issues/68):
Maxima Syntax Highlighting hangs when '$' is entered.

WetHat