### PR TITLE
Fix instructed directory for maxima_lexer.py

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -235,7 +235,7 @@ copy [maxima.js][] to the `maxima` directory, and update
 is pretty painful, sorry about that.
 
 The Pygments lexer for Maxima is maxima_lexer.py. To install it, find the
-Pygments installation directory, copy [maxima_lexer.py][] to that directory, and
+Pygments installation directory, copy [maxima_lexer.py][] to the `lexers` directory, and
 update `lexers/_mapping.py` as shown in [pygments-mapping-patch][]. Yes, this is
 pretty painful too.
 


### PR DESCRIPTION
Hello,

The Readme instructs to place maxima_lexer.py to the Pygments installation directory. However with this the error `nbconvert failed: No module named 'pygments.lexers.maxima_lexer'` is encountered when trying to exports notebooks to HTML format.

I think the correct directory is the `lexers` directory, and I corrected this to the instructions.

Thank you for the project!

