### PR TITLE
Add debugging

### DIFF
--- a/examples/Debugging.ipynb
+++ b/examples/Debugging.ipynb
@@ -2,39 +2,39 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{1}$}{\\it foo}\\left(y\\right):=\\mathbf{block}\\;\\left(\\left[ u:y^2 \\right]  , u:u+3 , u:u^2 , u\\right)\\]"
+       "\\[\\tag{${\\it \\%o}_{2}$}{\\it foo}\\left(y\\right):=\\mathbf{block}\\;\\left(\\left[ u:y^2 \\right]  , u:u+3 , u:u^2 , u\\right)\\]"
       ],
       "text/plain": [
        "                                      2                   2\n",
-       "(%o1)           foo(y) := block([u : y ], u : u + 3, u : u , u)"
+       "(%o2)           foo(y) := block([u : y ], u : u + 3, u : u , u)"
       ],
       "text/x-maxima": [
        "foo(y):=block([u:y^2],u:u+3,u:u^2,u)"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{2}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
+       "\\[\\tag{${\\it \\%o}_{3}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
       ],
       "text/plain": [
-       "(%o2)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
+       "(%o3)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
       ],
       "text/x-maxima": [
        "bar(x,y):=block([],(x:x+2,y:y+2,x:foo(y),x+y))"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -47,14 +47,14 @@
     "\n",
     "bar(x,y) := block([],(\n",
     "  x: x+2,\n",
-    "  y: y+2,\n",
+    "  y: y+2, \n",
     "  x: foo(y),\n",
     "  x+y));"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -67,16 +67,16 @@
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{3}$}365\\]"
+       "\\[\\tag{${\\it \\%o}_{5}$}365\\]"
       ],
       "text/plain": [
-       "(%o3)                                 365"
+       "(%o5)                                 365"
       ],
       "text/x-maxima": [
        "365"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/Debugging.ipynb
+++ b/examples/Debugging.ipynb
@@ -2,87 +2,250 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{2}$}{\\it foo}\\left(y\\right):=\\mathbf{block}\\;\\left(\\left[ u:y^2 \\right]  , u:u+3 , u:u^2 , u\\right)\\]"
-      ],
       "text/plain": [
-       "                                      2                   2\n",
-       "(%o2)           foo(y) := block([u : y ], u : u + 3, u : u , u)"
-      ],
-      "text/x-maxima": [
-       "foo(y):=block([u:y^2],u:u+3,u:u^2,u)"
+       "NIL"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
+      "text/plain": [
+       "FOO"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Type (to-maxima) to restart, ($quit) to quit Maxima.\n",
+      "Returning to Maxima\n"
+     ]
+    },
+    {
+     "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{3}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
+       "\\[\\tag{${\\it \\%o}_{4}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
       ],
       "text/plain": [
-       "(%o3)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
+       "(%o4)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
       ],
       "text/x-maxima": [
        "bar(x,y):=block([],(x:x+2,y:y+2,x:foo(y),x+y))"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "; file: CELL:3211916161.MAC.NEWEST\n",
+      "; in: DECLAIM (OPTIMIZE (DEBUG 3) (SAFETY 3) (SPEED 0))\n",
+      ";     (DECLAIM (OPTIMIZE (DEBUG 3) (SAFETY 3) (SPEED 0)))\n",
+      "; \n",
+      "; caught STYLE-WARNING:\n",
+      ";   DECLAIM where DECLARE was probably intended\n",
+      "; \n",
+      "; compilation unit finished\n",
+      ";   caught 1 STYLE-WARNING condition\n"
+     ]
     }
    ],
    "source": [
-    "foo(y) := block ([u:y^2],\n",
-    "  u: u+3,\n",
-    "  u: u^2,\n",
-    "  u);\n",
+    "to_lisp();\n",
+    "\n",
+    "(declaim (optimize (debug 3)\n",
+    "                   (safety 3)\n",
+    "                   (speed 0)))\n",
+    "\n",
+    "(defun foo (x)\n",
+    "  (break)\n",
+    "  (print (+ x 3))\n",
+    "  (+ x 4))\n",
+    "  \n",
+    "(to-maxima)\n",
     "\n",
     "bar(x,y) := block([],(\n",
     "  x: x+2,\n",
     "  y: y+2, \n",
-    "  x: foo(y),\n",
+    "  x: ?foo(y),\n",
     "  x+y));"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bkpt 0: "
+      "Bkpt 1: "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[SIMPLE-CONDITION] break\n"
      ]
     },
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{5}$}365\\]"
+       "\\[\\tag{${\\it \\%o}_{6}$}12\\]"
       ],
       "text/plain": [
-       "(%o5)                                 365"
+       "(%o6)                                 12"
       ],
       "text/x-maxima": [
-       "365"
+       "12"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "7 "
+     ]
     }
    ],
    "source": [
     "bar(1,2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "to_lisp(); (clj::get-source-map #P\"CELL:616192309.MAC.NEWEST\") (to-maxima)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "to_lisp();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ":lisp (print 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error(2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maxima::*stream-alist*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "break();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(remhash #P\"CELL:2115503282.MAC.NEWEST\" clj::*source-maps*)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(defun wibble (x)\n",
+    "  (print x)\n",
+    "  (+ x 7))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(wibble 8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(clj::get-source-map #P\"CELL:591804621.MAC.NEWEST\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(clj::reset-source-map #P\"CELL:4253716536.MAC.NEWEST\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(defun wibble (x)\n",
+    "  (print x)\n",
+    "  (+ x 1))"
    ]
   },
   {

--- a/examples/Debugging.ipynb
+++ b/examples/Debugging.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -11,7 +11,7 @@
        "NIL"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -21,7 +21,7 @@
        "FOO"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -29,7 +29,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
       "Type (to-maxima) to restart, ($quit) to quit Maxima.\n",
       "Returning to Maxima\n"
      ]
@@ -37,16 +36,16 @@
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{4}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
+       "\\[\\tag{${\\it \\%o}_{1}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
       ],
       "text/plain": [
-       "(%o4)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
+       "(%o1)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
       ],
       "text/x-maxima": [
        "bar(x,y):=block([],(x:x+2,y:y+2,x:foo(y),x+y))"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -55,7 +54,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "; file: CELL:3211916161.MAC.NEWEST\n",
+      "; file: CELL:3825463058.MAC.NEWEST\n",
       "; in: DECLAIM (OPTIMIZE (DEBUG 3) (SAFETY 3) (SPEED 0))\n",
       ";     (DECLAIM (OPTIMIZE (DEBUG 3) (SAFETY 3) (SPEED 0)))\n",
       "; \n",
@@ -90,46 +89,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bkpt 1: "
+      "Bkpt 0: "
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[SIMPLE-CONDITION] break\n"
-     ]
-    },
-    {
-     "data": {
-      "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{6}$}12\\]"
-      ],
-      "text/plain": [
-       "(%o6)                                 12"
-      ],
-      "text/x-maxima": [
-       "12"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "7 "
-     ]
+     "ename": "ABORT",
+     "evalue": "Cell execution halted.",
+     "output_type": "error",
+     "traceback": []
     }
    ],
    "source": [

--- a/examples/Debugging.ipynb
+++ b/examples/Debugging.ipynb
@@ -8,13 +8,30 @@
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{1}$}\\mbox{ foobar.mac }\\]"
+       "\\[\\tag{${\\it \\%o}_{1}$}{\\it foo}\\left(y\\right):=\\mathbf{block}\\;\\left(\\left[ u:y^2 \\right]  , u:u+3 , u:u^2 , u\\right)\\]"
       ],
       "text/plain": [
-       "(%o1)                             foobar.mac"
+       "                                      2                   2\n",
+       "(%o1)           foo(y) := block([u : y ], u : u + 3, u : u , u)"
       ],
       "text/x-maxima": [
-       "\"foobar.mac\""
+       "foo(y):=block([u:y^2],u:u+3,u:u^2,u)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\[\\tag{${\\it \\%o}_{2}$}{\\it bar}\\left(x , y\\right):=\\mathbf{block}\\;\\left(\\left[  \\right]  , \\left(x:x+2 , y:y+2 , x:{\\it foo}\\left(y\\right) , x+y\\right)\\right)\\]"
+      ],
+      "text/plain": [
+       "(%o2)  bar(x, y) := block([], (x : x + 2, y : y + 2, x : foo(y), x + y))"
+      ],
+      "text/x-maxima": [
+       "bar(x,y):=block([],(x:x+2,y:y+2,x:foo(y),x+y))"
       ]
      },
      "execution_count": 1,
@@ -23,7 +40,16 @@
     }
    ],
    "source": [
-    "load(\"foobar.mac\");"
+    "foo(y) := block ([u:y^2],\n",
+    "  u: u+3,\n",
+    "  u: u^2,\n",
+    "  u);\n",
+    "\n",
+    "bar(x,y) := block([],(\n",
+    "  x: x+2,\n",
+    "  y: y+2,\n",
+    "  x: foo(y),\n",
+    "  x+y));"
    ]
   },
   {
@@ -35,139 +61,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Turning on debugging debugmode(true)\n",
-      "\n",
-      "Bkpt 0 for foo (in /home/yitzi/Documents/git/maxima-jupyter/examples/foobar.mac line 1) \n"
-     ]
-    }
-   ],
-   "source": [
-    ":br foo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bkpt 0: (foobar.mac line 1, in function $FOO)\n",
-      "/home/yitzi/Documents/git/maxima-jupyter/examples/foobar.mac:1::\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "(dbm:1)  :bt\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#0: foo(y=5) (foobar.mac line 1)\n",
-      "#1: bar(x=2,y=3) (foobar.mac line 9)\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "(dbm:1)  :n\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(foobar.mac line 2, in function $FOO)\n",
-      "/home/yitzi/Documents/git/maxima-jupyter/examples/foobar.mac:2::\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "(dbm:1)  :n\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(foobar.mac line 3, in function $FOO)\n",
-      "/home/yitzi/Documents/git/maxima-jupyter/examples/foobar.mac:3::\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "(dbm:1)  u;\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "28"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "(dbm:1)  u:33;\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "33"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "(dbm:1)  :r\n"
+      "Bkpt 0: "
      ]
     },
     {
      "data": {
       "text/latex": [
-       "\\[\\tag{${\\it \\%o}_{3}$}1094\\]"
+       "\\[\\tag{${\\it \\%o}_{3}$}365\\]"
       ],
       "text/plain": [
-       "(%o3)                                1094"
+       "(%o3)                                 365"
       ],
       "text/x-maxima": [
-       "1094"
+       "365"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "bar(2,3);"
+    "bar(1,2);"
    ]
   },
   {
@@ -190,7 +105,7 @@
    "mimetype": "text/x-maxima",
    "name": "maxima",
    "pygments_lexer": "maxima",
-   "version": "5.44.0"
+   "version": "5.45.1"
   }
  },
  "nbformat": 4,

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -168,7 +168,8 @@
              (return-from jupyter:evaluate-code (values "ABORT" "Cell execution halted." nil)))
            :report-function (lambda (stream)
                               (write-string +abort-report+ stream))))
-      (jupyter:handling-errors (repl code source-path breakpoints)))))
+      (repl code source-path breakpoints))
+    (jupyter:handling-errors (repl code source-path breakpoints))))
 
 
 (defmethod jupyter:debug-continue ((k kernel) environment &optional restart-number)
@@ -190,6 +191,15 @@
 (defmethod jupyter:debug-in ((k kernel) environment)
   (if (kernel-in-maxima k)
     (invoke-restart 'into)
+    (call-next-method)))
+
+
+(defmethod jupyter:debug-evaluate ((kernel kernel) environment code frame)
+  (if (kernel-in-maxima kernel)
+    (make-debug-variable "EVAL"
+                         (my-eval (with-input-from-string (stream code)
+                                    (my-mread stream)))
+                         environment)
     (call-next-method)))
 
 

--- a/src/kernel.lisp
+++ b/src/kernel.lisp
@@ -142,18 +142,24 @@
     (restart-number
       (invoke-restart-interactively (elt (jupyter:debug-environment-restarts environment) restart-number)))
     (t
-      (invoke-restart 'continue))))
+      (invoke-restart 'step-continue))))
 
 
 (defmethod jupyter:debug-next ((k kernel) environment)
   (if (kernel-in-maxima k)
-    (invoke-restart 'next)
+    (invoke-restart 'step-next)
     (call-next-method)))
 
 
 (defmethod jupyter:debug-in ((k kernel) environment)
   (if (kernel-in-maxima k)
-    (invoke-restart 'into)
+    (invoke-restart 'step-into)
+    (call-next-method)))
+
+
+(defmethod jupyter:debug-out ((k kernel) environment)
+  (if (kernel-in-maxima k)
+    (error "No step out")
     (call-next-method)))
 
 

--- a/src/overrides.lisp
+++ b/src/overrides.lisp
@@ -298,24 +298,24 @@ $print is overridden so that math is displayed inline.
          (*diff-mspeclist* nil))
     (unwind-protect
         (restart-bind
-          ((cl:continue
+          ((maxima-jupyter::step-continue
              (lambda ()
                (return-from break-dbm-loop :resume))
              :report-function (lambda (stream)
-                                (write-string "Continue evaluation" stream)))
-           (maxima-jupyter::next
+                                (write-string "Continue normal execution" stream)))
+           (maxima-jupyter::step-next
              (lambda ()
                (step-next)
                (return-from break-dbm-loop :resume))
              :report-function (lambda (stream)
                                 (write-string "Step next" stream)))
-           (maxima-jupyter::into
+           (maxima-jupyter::step-into
              (lambda ()
                (step-into)
                (return-from break-dbm-loop :resume))
              :report-function (lambda (stream)
                                 (write-string "Step into" stream))))
-          (let ((environment (make-instance 'jupyter:debug-environment
+          (let ((environment (make-instance 'jupyter/common-lisp:debug-environment
                                             :condition nil
                                             :restarts (compute-restarts)
                                             :frames (maxima-jupyter::calculate-debug-frames))))

--- a/src/overrides.lisp
+++ b/src/overrides.lisp
@@ -81,7 +81,7 @@ to send the code to the client.
         for expr = (dbm-read in-stream nil) then (dbm-read in-stream nil)
         while expr
         do
-        (jupyter:enqueue-input maxima-jupyter::*kernel*
+        (jupyter:enqueue-input jupyter:*kernel*
           (with-output-to-string (f)
             (mgrind (third expr) f)
             (write-char (if (eql (caar expr) 'displayinput) #\; #\$) f)))))
@@ -325,3 +325,6 @@ $print is overridden so that math is displayed inline.
       (restore-bindings)))
   :resume)
 
+
+(defun mbreak-loop ()
+  (break-dbm-loop nil))

--- a/src/results.lisp
+++ b/src/results.lisp
@@ -16,31 +16,19 @@ Standard MIME types
        (listp (car code))
        (keywordp (caar code))))
 
-(defun lisp-result-p (code)
-  (and (listp code)
-       (listp (car code))
-       (eq (caar code) ':lisp)))
-
-(defun mlabel-result-p (code)
-  (and (listp code)
-       (listp (car code))
-       (eq (caar code) 'maxima::displayinput)))
 
 (defun displayinput-result-p (code)
   (and (listp code)
        (listp (car code))
-       (eq (caar code) 'maxima::displayinput)))
+       (eq (caar code) 'maxima::displayinput))
+       (not (eq :no-output (third code))))
 
-(defun mlabel-input-result-p (code)
-  (and (listp code)
-       (listp (car code))
-       (eq (caar code) 'maxima::mlabel)
-       (starts-with-subseq (string maxima::$inchar) (string (second code)))))
 
 (defun mtext-result-p (code)
   (and (listp code)
          (listp (car code))
          (eq (caar code) 'maxima::mtext)))
+
 
 (defun plot-p (value)
   (and (listp value)
@@ -51,8 +39,6 @@ Standard MIME types
        (or (ends-with-subseq ".gnuplot" (second value))
            (ends-with-subseq ".gnuplot_pipes" (second value)))))
 
-(defun sexpr-to-text (value)
-  (format nil "~S" value))
 
 (defun mexpr-to-text (value)
   (string-trim '(#\Newline)
@@ -61,6 +47,7 @@ Standard MIME types
                        (maxima::*alt-display2d* nil))
                    (maxima::displa value)))))
 
+
 (defun mexpr-to-latex (value)
   (let ((env (maxima::get-tex-environment value)))
     (apply #'concatenate 'string
@@ -68,6 +55,7 @@ Standard MIME types
                    (maxima::tex value
                                 (list (car env)) (list (cdr env))
                                 'maxima::mparen 'maxima::mparen)))))
+
 
 (defun mexpr-to-maxima (value)
   (let ((maxima::*display-labels-p* nil))


### PR DESCRIPTION
We probably need to wait untill Quicklisp updates to merge this PR, but in case you want to kick the tires and light the fires here it is. In order to try out you will need 

1. a git clone of common-lisp-jupyter in `~/quicklisp/local-projects`
2. An installation of JupyterLab
3. jupyterlab-debugger-restarts via `jupyter-labextension install jupyterlab-debugger-restarts`

In Maxima breakpoints, evaluation in frame and stepping works. The only thing missing from the stepper is step-out as it seems that Maxima doesn't have that.

In Lisp mode for SBCL breakpoints sort of work. Stepping and evaluation in frame also work.

Everything else works in both modes, i.e. variable inspection, source code loading, etc.

There are some things that have changed, mainly I was not able to use `dbm-read` since it doesn't track source position. That means no more breakpoint commands including `:lisp` or `:lisp-quiet`. 

The Maxima REPL loop is now integrated into common-lisp-jupyter so that you can switch back and forth with `to_lisp()` and `(to-maxima)` and actually set breakpoints, track line position in the Lisp section in the same cell! 