### PR TITLE
Updates for changes in plot2d return format

### DIFF
--- a/src/overrides.lisp
+++ b/src/overrides.lisp
@@ -116,7 +116,7 @@ plot is inside of a block.
 (defover $plot2d (orig &rest args)
   (let ((value (apply orig args)))
     (when (maxima-jupyter::plot-p value)
-      (jupyter-file (third value) t))
+      (jupyter-file (second value) t))
     value))
 
 #|
@@ -129,7 +129,7 @@ plot is inside of a block.
 (defover $plot3d (orig &rest args)
   (let ((value (apply orig args)))
     (when (maxima-jupyter::plot-p value)
-      (jupyter-file (third value) t))
+      (jupyter-file (second value) t))
     value))
 
 
@@ -257,7 +257,7 @@ the plot is inside of a block.
 (defover $mandelbrot (orig &rest args)
   (let ((value (apply orig args)))
     (when (maxima-jupyter::plot-p value)
-      (jupyter-file (third value) t))
+      (jupyter-file (second value) t))
     value))
 
 #|
@@ -270,7 +270,7 @@ plot is inside of a block.
 (defover $julia (orig &rest args)
   (let ((value (apply orig args)))
     (when (maxima-jupyter::plot-p value)
-      (jupyter-file (third value) t))
+      (jupyter-file (second value) t))
     value))
 
 #|

--- a/src/results.lisp
+++ b/src/results.lisp
@@ -33,11 +33,9 @@ Standard MIME types
 (defun plot-p (value)
   (and (listp value)
        (eq (caar value) 'maxima::mlist)
-       (eq (list-length value) 3)
+       (eq (list-length value) 2)
        (stringp (second value))
-       (stringp (third value))
-       (or (ends-with-subseq ".gnuplot" (second value))
-           (ends-with-subseq ".gnuplot_pipes" (second value)))))
+       (probe-file (second value))))
 
 
 (defun mexpr-to-text (value)


### PR DESCRIPTION
Some of the demos need to be updated because contourplot and others have been deprecated. This just fixes logic for the changes in return format of plot2d.

Fixes #118 