### PR TITLE
Debian-based docker file building maxima from source

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,68 +1,47 @@
 FROM debian:bookworm-slim as debbase
 
-ARG NB_USER=app
-ARG NB_UID=1000
-
-RUN useradd --create-home --shell=/bin/false --uid=${NB_UID} ${NB_USER}
-
-
-ENV USER ${NB_USER}
-ENV HOME /home/${NB_USER}
-ENV JUPYTER_PATH=${HOME}/.local/share/jupyter/
-ENV JUPYTERLAB_DIR=${HOME}/.local/share/jupyter/lab/
-ENV PATH "${HOME}/.local/bin:${PATH}"
-
 RUN apt-get update && apt-get -q -y install sbcl curl
+
+ENV USER=app NB_UID=1000
+ENV HOME=/home/${USER} 
+ENV JUPYTER_PATH=${HOME}/.local/share/jupyter/ JUPYTERLAB_DIR=${HOME}/.local/share/jupyter/lab/ \
+    PATH="${HOME}/.local/bin:${PATH}"
+
+
+RUN useradd --create-home --shell=/bin/false --uid=${NB_UID} ${USER}
+
+
 
 FROM debbase as buildsys
 
-RUN apt-get update && apt-get -q -y install cmake  gcc libtool git autoconf python3 binutils g++ gperf make curl
+RUN apt-get update && apt-get -q -y install cmake gcc libtool git autoconf \
+                                    python3 binutils g++ gperf make curl \
+				    texinfo \
+				    python3-minimal python3-pip \
+				    python3-venv \
+				    libzmq3-dev
 
-RUN apt-get update && apt-get -q -y install texinfo
 
 ENV maxima_build tags/5.47.0
 
 RUN git clone https://git.code.sf.net/p/maxima/code maxima-code && \
     cd maxima-code && \
-    git checkout ${maxima_build}
-
-RUN cd maxima-code && \
+    git checkout ${maxima_build} && \
     mkdir dist && \
     ./bootstrap && \
     ./configure --enable-sbcl-exec --enable-quiet-build --prefix=/maxima && \
-    make -s -j 2&& \
+    make -s -j$(nproc) && \
     make install
 
-RUN apt-get update &&  apt-get -q -y install python3-minimal python3-pip
-
-RUN apt-get update &&  apt-get -q -y install python3-venv
 
 WORKDIR ${HOME}
-USER ${NB_USER}
+USER ${USER}
 
-RUN python3 -m venv jupyterenv
-RUN jupyterenv/bin/pip install   jupyter
-
-
-FROM debbase
-
-ARG NB_USER=app
-ARG NB_UID=1000
+RUN python3 -m venv jupyterenv && \
+    jupyterenv/bin/pip install   jupyter
 
 
-COPY --from=buildsys /maxima /maxima
-COPY --from=buildsys /home/app/jupyterenv /home/app/jupyterenv
-
-RUN apt-get update &&  apt-get -q -y install python3-minimal 
-
-
-WORKDIR ${HOME}
-USER ${NB_USER}
-
-ENV NVM_DIR ${HOME}/nvm
-ENV NODE_VERSION 22
-
-
+ENV NVM_DIR=${HOME}/nvm NODE_VERSION=22
 
 RUN mkdir -p $NVM_DIR &&  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
@@ -72,11 +51,6 @@ RUN source $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default
-
-USER root
-# Need cc for zeromq wrapper
-RUN apt-get update && apt-get -q -y install   gcc
-USER ${NB_USER}
 
 RUN source $NVM_DIR/nvm.sh && \
     jupyterenv/bin/jupyter server extension enable --user --py jupyterlab && \
@@ -94,32 +68,35 @@ WORKDIR ${HOME}/maxima-jupyter
 # Use .dockerignore to avoid copying unnecsary files such as ".git" directory
 COPY .  ${HOME}/maxima-jupyter/
 
-RUN chown -R ${NB_UID} ${HOME} && chgrp -R ${NB_USER} ${HOME}
+RUN chown -R ${NB_UID} ${HOME} && chgrp -R ${USER} ${HOME}
 
-RUN apt-get update &&  apt-get -q -y install --no-install-recommends --no-install-suggests libzmq3-dev
-
-# This is just for minimisng the image
-RUN apt-get update &&  apt-get -q -y install ncdu
-
-USER ${NB_USER}
+USER ${USER}
 
 RUN source $NVM_DIR/nvm.sh && ~/jupyterenv/bin/jupyter lab build
 
 # This is needed to find  the sbcl contrib directory for asdf etc
 ENV SBCL_HOME /usr/lib/sbcl
 
-
 RUN /maxima/bin/maxima --batch-string="load(\"load-maxima-jupyter.lisp\");jupyter_install();"
 
-WORKDIR ${HOME}/maxima-jupyter/examples
 
-ENV PATH "${PATH}:/maxima/bin"
+FROM debbase
 
-RUN rm -rf ${HOME}/.local/share/jupyter/lab/staging
-RUN rm -rf $NVM_DIR
-RUN rm -rf ${HOME}/.yarn
-
-USER root
+RUN apt-get update &&  apt-get -q -y install  python3-minimal libzmq3-dev gnuplot-nox
 RUN find /usr -iname "*.a" -delete
 
-USER ${NB_USER}
+USER ${USER}
+
+# Older Docker does not support merging these statements together...
+COPY --from=buildsys /maxima /maxima
+COPY --from=buildsys /home/app/jupyterenv /home/app/jupyterenv
+COPY --from=buildsys /home/app/quicklisp /home/app/quicklisp
+COPY --from=buildsys /home/app/maxima-jupyter /home/app/maxima-jupyter
+COPY --from=buildsys /home/app/.sbclrc /home/app/.sbclrc
+COPY --from=buildsys /home/app/.local /home/app/.local
+COPY --from=buildsys /home/app/.jupyter /home/app/.jupyter
+COPY --from=buildsys /home/app/.cache /home/app/.cache
+
+ENV PATH="${PATH}:/maxima/bin:${HOME}/jupyterenv/bin" SBCL_HOME=/usr/lib/sbcl
+WORKDIR ${HOME}/maxima-jupyter/examples
+

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,43 @@
+FROM debian:bookworm-slim as buildsys
+
+ARG NB_USER=app
+ARG NB_UID=1000
+
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+ENV JUPYTER_PATH=${HOME}/.local/share/jupyter/
+ENV JUPYTERLAB_DIR=${HOME}/.local/share/jupyter/lab/
+ENV PATH "${HOME}/.local/bin:${PATH}"
+
+RUN apt-get update && apt-get -q -y install sbcl
+RUN apt-get update && apt-get -q -y install cmake  gcc libtool git autoconf python3 binutils g++ gperf make curl
+
+RUN apt-get update && apt-get -q -y install texinfo
+
+ENV maxima_build tags/5.47.0
+
+RUN git clone https://git.code.sf.net/p/maxima/code maxima-code && \
+    cd maxima-code && \
+    git checkout ${maxima_build}
+
+RUN cd maxima-code && \
+    mkdir dist && \
+    ./bootstrap && \
+    ./configure --enable-sbcl-exec --enable-quiet-build --prefix=`pwd`/dist && \
+    make -s -j 2&& \
+    make install
+
+FROM debian:bookworm-slim
+
+COPY --from=buildsys /maxima-code/dist /maxima 
+
+RUN apt-get update &&  apt-get -q -y install python3-jupyterlab-server
+
+RUN apt-get update &&  apt-get -q -y install sbcl curl
+
+RUN jupyter serverextension enable --user --py jupyterlab; \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager; \
+    curl -kLO https://beta.quicklisp.org/quicklisp.lisp; \
+    sbcl --non-interactive --load quicklisp.lisp \
+      --eval "(quicklisp-quickstart:install)" \
+      --eval "(ql-util:without-prompting (ql:add-to-init-file))"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,10 @@
-FROM debian:bookworm-slim as buildsys
+FROM debian:bookworm-slim as debbase
 
 ARG NB_USER=app
 ARG NB_UID=1000
+
+RUN useradd --create-home --shell=/bin/false --uid=${NB_UID} ${NB_USER}
+
 
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
@@ -9,7 +12,10 @@ ENV JUPYTER_PATH=${HOME}/.local/share/jupyter/
 ENV JUPYTERLAB_DIR=${HOME}/.local/share/jupyter/lab/
 ENV PATH "${HOME}/.local/bin:${PATH}"
 
-RUN apt-get update && apt-get -q -y install sbcl
+RUN apt-get update && apt-get -q -y install sbcl curl
+
+FROM debbase as buildsys
+
 RUN apt-get update && apt-get -q -y install cmake  gcc libtool git autoconf python3 binutils g++ gperf make curl
 
 RUN apt-get update && apt-get -q -y install texinfo
@@ -23,21 +29,97 @@ RUN git clone https://git.code.sf.net/p/maxima/code maxima-code && \
 RUN cd maxima-code && \
     mkdir dist && \
     ./bootstrap && \
-    ./configure --enable-sbcl-exec --enable-quiet-build --prefix=`pwd`/dist && \
+    ./configure --enable-sbcl-exec --enable-quiet-build --prefix=/maxima && \
     make -s -j 2&& \
     make install
 
-FROM debian:bookworm-slim
+RUN apt-get update &&  apt-get -q -y install python3-minimal python3-pip
 
-COPY --from=buildsys /maxima-code/dist /maxima 
+RUN apt-get update &&  apt-get -q -y install python3-venv
 
-RUN apt-get update &&  apt-get -q -y install python3-jupyterlab-server
+WORKDIR ${HOME}
+USER ${NB_USER}
 
-RUN apt-get update &&  apt-get -q -y install sbcl curl
+RUN python3 -m venv jupyterenv
+RUN jupyterenv/bin/pip install   jupyter
 
-RUN jupyter serverextension enable --user --py jupyterlab; \
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager; \
-    curl -kLO https://beta.quicklisp.org/quicklisp.lisp; \
+
+FROM debbase
+
+ARG NB_USER=app
+ARG NB_UID=1000
+
+
+COPY --from=buildsys /maxima /maxima
+COPY --from=buildsys /home/app/jupyterenv /home/app/jupyterenv
+
+RUN apt-get update &&  apt-get -q -y install python3-minimal 
+
+
+WORKDIR ${HOME}
+USER ${NB_USER}
+
+ENV NVM_DIR ${HOME}/nvm
+ENV NODE_VERSION 22
+
+
+
+RUN mkdir -p $NVM_DIR &&  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+SHELL ["/bin/bash", "-c"] 
+
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+USER root
+# Need cc for zeromq wrapper
+RUN apt-get update && apt-get -q -y install   gcc
+USER ${NB_USER}
+
+RUN source $NVM_DIR/nvm.sh && \
+    jupyterenv/bin/jupyter server extension enable --user --py jupyterlab && \
+    jupyterenv/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
+    curl -kLO https://beta.quicklisp.org/quicklisp.lisp && \
     sbcl --non-interactive --load quicklisp.lisp \
       --eval "(quicklisp-quickstart:install)" \
       --eval "(ql-util:without-prompting (ql:add-to-init-file))"
+
+USER root
+
+
+WORKDIR ${HOME}/maxima-jupyter
+
+# Use .dockerignore to avoid copying unnecsary files such as ".git" directory
+COPY .  ${HOME}/maxima-jupyter/
+
+RUN chown -R ${NB_UID} ${HOME} && chgrp -R ${NB_USER} ${HOME}
+
+RUN apt-get update &&  apt-get -q -y install --no-install-recommends --no-install-suggests libzmq3-dev
+
+# This is just for minimisng the image
+RUN apt-get update &&  apt-get -q -y install ncdu
+
+USER ${NB_USER}
+
+RUN source $NVM_DIR/nvm.sh && ~/jupyterenv/bin/jupyter lab build
+
+# This is needed to find  the sbcl contrib directory for asdf etc
+ENV SBCL_HOME /usr/lib/sbcl
+
+
+RUN /maxima/bin/maxima --batch-string="load(\"load-maxima-jupyter.lisp\");jupyter_install();"
+
+WORKDIR ${HOME}/maxima-jupyter/examples
+
+ENV PATH "${PATH}:/maxima/bin"
+
+RUN rm -rf ${HOME}/.local/share/jupyter/lab/staging
+RUN rm -rf $NVM_DIR
+RUN rm -rf ${HOME}/.yarn
+
+USER root
+RUN find /usr -iname "*.a" -delete
+
+USER ${NB_USER}

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -79,6 +79,8 @@ ENV SBCL_HOME /usr/lib/sbcl
 
 RUN /maxima/bin/maxima --batch-string="load(\"load-maxima-jupyter.lisp\");jupyter_install();"
 
+# Remove unneeded files (newer docker could use --exclude on copy?)
+RUN rm -rf ${HOME}/.local/share/jupyter/lab/staging
 
 FROM debbase
 


### PR DESCRIPTION
A  Dockerfile based on Debian, building maxima from source, installing up-to-date node, install jupyter with pip

It has the following advantages:
1. Debian in not a rolling distribution, so it  a more stable base to build the docker file on. I found the Arch-based file would sometimes not build due to recent changes to the distro.
2. Multi-stage build means that the build dependencies are not all included in the run-time system
3. Recent, fixed version of node installed with nvm
4. Pip-installed recent jupyter
5. Maxima built from source
6. Final image is significantly smaller -- I find 1GB vs 3GB for the Arch based image